### PR TITLE
Restrict NEL to "Potentially Trustworthy" origins

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,16 +92,14 @@
 
     <section>
       <h2>Policy Delivery and Processing</h2>
-      <p>The server delivers the <a>NEL policy</a> to the user agent via an HTTP response header field (<a>NEL header field</a>). If the result of executing <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">is-origin-trusworthy</a> algorithm ([[!POWERFUL-FEATURES]]) on origin of the <a>NEL policy</a> is `Potentially Trustworthy` then the user agent MUST either:</p>
+      <p>The server delivers the <a>NEL policy</a> to the user agent via an HTTP response header field (<a>NEL header field</a>). If the result of executing <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">is-origin-trusworthy</a> algorithm ([[!POWERFUL-FEATURES]]) on <a href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> that served the <a>NEL policy</a> is `Potentially Trustworthy` then the user agent MUST either:</p>
 
       <ul>
-        <li>Register the host as a <a>known NEL host</a> if it is not already registered.</li>
-        <li>Update the registered policy for the <a>known NEL host</a> if the provided policy is different than that already stored by the user agent.</li>
+        <li>Register the host as a <a>known NEL origin</a> if it is not already registered.</li>
+        <li>Update the registered policy for the <a>known NEL origin</a> if the provided policy is different than that already stored by the user agent.</li>
       </ul>
 
       <p>Otherwise, if the result of the algorithm is **not** `Potentionally Trustworthy`, then the user MUST ignore the provided <a>NEL policy</a>.</p>
-
-      <p class="note">The application does not need to be HTTPS-only to take advantage of NEL. To enable NEL reporting for an HTTP site the application can fetch a single "NEL registration resource" (e.g fetch an empty pixel) from the same domain name but over a secure transport - e.g. `http://example.com` can fetch `https://example.com/registerNEL`. Once registered, the NEL policy applies to both HTTPS and HTTP fetches for that <a>NEL host</a> - i.e. an NEL registration for `https://example.com` also applies to `http://example.com` fetches.</p>
 
       <section>
         <h2>`NEL` Header Field</h2>
@@ -149,14 +147,14 @@ directive-value   = 1\\\*absolute-URI
         </section>
         <section>
           <h2>The `max-age` Directive</h2>
-          <p>The REQUIRED <dfn>max-age</dfn> directive specifies the number of seconds, after the reception of the NEL header field, during which the user agent regards the host (from whom the policy was received) as a <a>known NEL host</a>. The ABNF grammar for the name and value of the directive is:</p>
+          <p>The REQUIRED <dfn>max-age</dfn> directive specifies the number of seconds, after the reception of the NEL header field, during which the user agent regards the host (from whom the policy was received) as a <a>known NEL origin</a>. The ABNF grammar for the name and value of the directive is:</p>
 
           <pre>
 directive-name    = "max-age"
 directive-value   = delta-seconds
           </pre>
 
-          <p>See [[!RFC7234]] section 1.2.1 for definition of `delta-seconds`. A <a>max-age</a> value of zero (i.e. "max-age=0") signals the user agent to cease regarding the host as a <a>known NEL host</a>, including the <a>includeSubDomains</a> directive if provided.</p>
+          <p>See [[!RFC7234]] section 1.2.1 for definition of `delta-seconds`. A <a>max-age</a> value of zero (i.e. "max-age=0") signals the user agent to cease regarding the host as a <a>known NEL origin</a>, including the <a>includeSubDomains</a> directive if provided.</p>
         </section>
         <section>
           <h2>The `includeSubDomains` Directive</h2>
@@ -168,11 +166,9 @@ directive-value   = delta-seconds
     <section>
       <h2>Policy Storage and Maintenance</h2>
 
-      <p>An HTTP host declares itself an <dfn>NEL host</dfn> by issuing an <a>NEL policy</a>, which is communicated via the <a>NEL header field</a> from a <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">`Potentially Trustworthy` origin</a>. Upon error-free receipt and processing of this header by a conformant user agent, the user agent regards the host as a <dfn>known NEL host</dfn>.</p>
+      <p>An HTTP host declares itself an <dfn>NEL origin</dfn> by issuing an <a>NEL policy</a>, which is communicated via the <a>NEL header field</a> from a <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">`Potentially Trustworthy` origin</a>. Upon error-free receipt and processing of this header by a conformant user agent, the user agent regards the host as a <dfn>known NEL origin</dfn>.</p>
 
-      <p>The user agent MUST store and index NEL policies based strictly upon the domain names of the issuing <a title="NEL host">NEL hosts</a>. An <a>NEL policy</a> may contain an optional <a>includeSubDomains</a> directive specifying that this policy also applies to any hosts whose domain names are subdomains of the <a title="known NEL host">known NEL host's</a> domain name.</p>
-
-      <p>The user agent MUST maintain the <a>NEL policy</a> of any given <a>NEL host</a> separately from any NEL policies issued by any other <a title="NEL host">NEL hosts</a> whose domain names are superdomains or subdomains of the given <a title="NEL host">NEL host's</a> domain name. Only the given <a>NEL host</a> can update or cause deletion of its <a>NEL policy</a>. This is accomplished by sending a <a>NEL header field</a> to the user agent with new values for the policy <a title="report-uri">report URL</a>, <a title="max-age">time duration</a>, and <a title="includeSubDomains">subdomain applicability</a>. Thus, the user agent MUST store the "freshest" <a>NEL policy</a> information on behalf of an <a>NEL host</a>, and specifying a zero time duration MUST cause the user agent to delete the <a>NEL policy</a> (including any asserted <a>includeSubDomains</a> directive) for that <a>NEL host</a>.</p>
+      <p>The user agent MUST maintain the <a>NEL policy</a> of any given <a>NEL origin</a> separately from any NEL policies issued by any other <a title="NEL origin">NEL origins</a>. Only the given <a>NEL origin</a> can update or cause deletion of its <a>NEL policy</a>. This is accomplished by sending a <a>NEL header field</a> to the user agent with new values for the policy <a title="report-uri">report URL</a>, <a title="max-age">time duration</a>, and <a title="includeSubDomains">subdomain applicability</a>. Thus, the user agent MUST store the "freshest" <a>NEL policy</a> information on behalf of an <a>NEL origin</a>, and specifying a zero time duration MUST cause the user agent to delete the <a>NEL policy</a> (including any asserted <a>includeSubDomains</a> directive) for that <a>NEL origin</a>.</p>
     </section>
 
     <section>
@@ -196,13 +192,13 @@ directive-value   = delta-seconds
 
       <p class="note">Note that the above definition of "network error" is different from definition in [[Fetch]]. The definition of <a>network error</a> in this specification is a subset of [[Fetch]] definition - i.e. all of the above conditions would trigger a "network error" in [[Fetch]] processing, but conditions such as blocked requests due to mixed content, CORS failures, etc., would not.</p>
 
-      <p>When a <a>network error</a> occurs for a URL that belongs to a <a>known NEL host</a> the user agent SHOULD log the error and attempt to deliver it to the <a title="report-uri">report URL</a> defined by the <a>NEL policy</a> of the associated <a>NEL host</a>:</p>
+      <p>When a <a>network error</a> occurs for a URL that belongs to a <a>known NEL origin</a> the user agent SHOULD log the error and attempt to deliver it to the <a title="report-uri">report URL</a> defined by the <a>NEL policy</a> of the associated <a>NEL origin</a>:</p>
 
       <ul>
         <li>The user agent SHOULD make best effort to deliver the error report as soon as possible to provide the necessary real-time feedback.</li>
         <li>The user agent MAY delay delivery of the report to account for poor or missing connectivity (e.g. temporarily offline due to poor service).</li>
         <li>The user agent MAY abandon delivery of the report if the time of error exceeds 24 hours, or if the <a title="report-uri">report URL</a> is not responding or returns an error.</li>
-        <li>The user agent MAY aggregate multiple error reports for the same <a>NEL host</a> and deliver them in a single report.</li>
+        <li>The user agent MAY aggregate multiple error reports for the same <a>NEL origin</a> and deliver them in a single report.</li>
       </ul>
 
       <p>To generate a <dfn>network error object</dfn>, the user agent MUST use an algorithm equivalent to the following:</p>
@@ -355,7 +351,7 @@ directive-value   = delta-seconds
         <li>For each <a title="report-uri">report URL</a> in the <a>set of report URLs</a>:
 
         <ol>
-          <li><a href="http://www.w3.org/html/wg/drafts/html/CR/webappapis.html#queue-a-task">Queue a task</a> to <a href="http://www.w3.org/html/wg/drafts/html/CR/infrastructure.html#fetch">fetch</a> <a title="report-uri">report URL</a> using HTTP method POST, with a `Content-Type` header field of `application/nel-report`, and an entity body consisting of <a>report body</a>. If the origin of <a title="report-uri">report URL</a> is not the same as the origin of the <a>NEL host</a> for which the report is generated, the block cookies flag MUST also be set. The user agent MUST NOT follow redirects when fetching this resource and ignore the fetched response if one is provided. The <a href="https://www.w3.org/TR/html5/webappapis.html#task-source">task source</a> for these <a href="https://www.w3.org/TR/html5/webappapis.html#concept-task">tasks</a> is the <dfn>Network Error Logging task source</dfn>.</li>
+          <li><a href="http://www.w3.org/html/wg/drafts/html/CR/webappapis.html#queue-a-task">Queue a task</a> to <a href="http://www.w3.org/html/wg/drafts/html/CR/infrastructure.html#fetch">fetch</a> <a title="report-uri">report URL</a> using HTTP method POST, with a `Content-Type` header field of `application/nel-report`, and an entity body consisting of <a>report body</a>. If the origin of <a title="report-uri">report URL</a> is not the same as the origin of the <a>NEL origin</a> for which the report is generated, the block cookies flag MUST also be set. The user agent MUST NOT follow redirects when fetching this resource and ignore the fetched response if one is provided. The <a href="https://www.w3.org/TR/html5/webappapis.html#task-source">task source</a> for these <a href="https://www.w3.org/TR/html5/webappapis.html#concept-task">tasks</a> is the <dfn>Network Error Logging task source</dfn>.</li>
 
           <li>If the fetch is successful (2xx HTTP response code), the user agent MUST abort the remaining steps.</li>
 
@@ -386,14 +382,9 @@ directive-value   = delta-seconds
 &lt; NEL: report-uri="https://example.com/report"; max-age=2592000
         </pre>
 
-        <p>The above <a>NEL policy</a> provided in the server response specifies that the user agent should register a new <a>NEL policy</a>, or update an existing one if one already exists, for the `example.com` <a>NEL host</a>: the user agent should report network errors to `https://example.com/report` and the policy applies for 2592000 seconds (30 days).</p>
+        <p>The above <a>NEL policy</a> provided in the server response specifies that the user agent should register a new <a>NEL policy</a>, or update an existing one if one already exists, for the `example.com` <a>NEL origin</a>: the user agent should report network errors to `https://example.com/report` and the policy applies for 2592000 seconds (30 days).</p>
 
-        <p>Note that above registration will only succeed if the response is communicated from a `Potentially Trustworthy` origin - see <a href="#policy-delivery-and-processing"></a>. To register an NEL policy:</p>
-
-        <ul>
-          <li>An HTTPS application can respond with the <a>NEL policy</a> in its response.</li>
-          <li>An HTTP application can provide a single "NEL registration resource" on the same domain but over a secure transport.</li>
-        </ul>
+        <p>Note that above registration will only succeed if the response is communicated from a `Potentially Trustworthy` origin - see <a href="#policy-delivery-and-processing"></a>.
 
         <pre class="example">
 &gt; GET / HTTP/1.1
@@ -415,7 +406,7 @@ directive-value   = delta-seconds
 &lt; NEL: report-uri="https://example.com/report" "https://other-origin.com/report"; max-age=2592000; includeSubDomains
         </pre>
 
-        <p>The above <a>NEL policy</a> provided in the server response specifies that the user agent should report network errors to `https://example.com/report`, or `https://other-origin.com/report` if the former is unreachable. Further, the policy is extended to all of the subdomains of the issuing <a>NEL host</a> - see <a href="#the-includesubdomains-directive"></a>.</p>
+        <p>The above <a>NEL policy</a> provided in the server response specifies that the user agent should report network errors to `https://example.com/report`, or `https://other-origin.com/report` if the former is unreachable. Further, the policy is extended to all of the subdomains of the issuing <a>NEL origin</a> - see <a href="#the-includesubdomains-directive"></a>.</p>
 
         <pre class="example">
 &gt; GET / HTTP/1.1
@@ -426,7 +417,7 @@ directive-value   = delta-seconds
 &lt; NEL: max-age=0
         </pre>
 
-        <p>The above <a>NEL policy</a> provided in the server response contains <a>max-age</a> set to zero, which indicates that the user agent must delete the current registered <a>NEL policy</a> associated with the `example.com` <a>NEL Host</a> and all of its subdomains:</p>
+        <p>The above <a>NEL policy</a> provided in the server response contains <a>max-age</a> set to zero, which indicates that the user agent must delete the current registered <a>NEL policy</a> associated with the `example.com` <a>NEL origin</a> and all of its subdomains:</p>
         <ul>
           <li><a>includeSubDomains</a> is implicit when <a>max-age</a> is zero</li>
           <li><a>report-uri</a> is optional when removing a previously registered policy</li>
@@ -435,7 +426,7 @@ directive-value   = delta-seconds
 
       <section>
         <h2>Sample Network Error Reports</h2>
-        <p>This section contains an example network error report the user agent might send when a network error is encountered for a <a>known NEL host</a>.</p>
+        <p>This section contains an example network error report the user agent might send when a network error is encountered for a <a>known NEL origin</a>.</p>
 
         <pre class="highlight">
 {
@@ -454,7 +445,7 @@ directive-value   = delta-seconds
         }
         </pre>
 
-        <p>The above report indicates that the user agent attempted to navigate from "example.com" to "www.example.com" (<a>known NEL host</a>), which successfully resolved to the "123.122.121.120" IP address. However, while the user agent received a "200" response from the server via the "h2-15" protocol, it encountered a protocol error in the exchange and was forced to abandon the navigation. 823 milliseconds elapsed between the start of navigation and when the user agent aborted the navigation. Finally, the user agent sent this report immediately after the network error was encountered - i.e. the report age is 0.</p>
+        <p>The above report indicates that the user agent attempted to navigate from "example.com" to "www.example.com" (<a>known NEL origin</a>), which successfully resolved to the "123.122.121.120" IP address. However, while the user agent received a "200" response from the server via the "h2-15" protocol, it encountered a protocol error in the exchange and was forced to abandon the navigation. 823 milliseconds elapsed between the start of navigation and when the user agent aborted the navigation. Finally, the user agent sent this report immediately after the network error was encountered - i.e. the report age is 0.</p>
 
         <pre class="highlight">
 {
@@ -473,7 +464,7 @@ directive-value   = delta-seconds
         }
         </pre>
 
-        <p>The above report indicates that the user agent attempted to fetch  "https://widget.com/thing.js", which belongs to a previously registered <a>NEL host</a>, from "www.example.com" origin. However, the user agent was unable to resolve the DNS name and the request was aborted by the user agent after 143 milliseconds. Because "widget.com" is a known NEL host, a network error report was logged and sent to the report URL specified by the NEL policy of that host immediately after the network error was encountered - i.e. the report age is 0.</p>
+        <p>The above report indicates that the user agent attempted to fetch  "https://widget.com/thing.js", which belongs to a previously registered <a>NEL origin</a>, from "www.example.com" origin. However, the user agent was unable to resolve the DNS name and the request was aborted by the user agent after 143 milliseconds. Because "widget.com" is a known NEL origin, a network error report was logged and sent to the report URL specified by the NEL policy of that host immediately after the network error was encountered - i.e. the report age is 0.</p>
       </section>
     </section>
 
@@ -493,7 +484,7 @@ directive-value   = delta-seconds
 
         <p>A typical application requires dozens of resources, the fetching of which is typically initiated via HTML, CSS, or JavaScript. The application requesting such resources can observe failures of most such fetches (e.g. via `onerror` callbacks), but it does not have access to the detailed network error report of why the failure has occurred - e.g. DNS failure, TCP error, TLS protocol violation, etc.</p>
 
-        <p>To address this, the application can register relevant NEL policies with the user agent for the first-party hosts from which the subresources are being fetched. Then, if such a policy is present and a network error is encountered for a resource associated with a registered <a>NEL host</a>, the user agent will report the detailed network error report and enable the application developers to investigate the error.</p>
+        <p>To address this, the application can register relevant NEL policies with the user agent for the first-party hosts from which the subresources are being fetched. Then, if such a policy is present and a network error is encountered for a resource associated with a registered <a>NEL origin</a>, the user agent will report the detailed network error report and enable the application developers to investigate the error.</p>
       </section>
 
       <section>
@@ -501,7 +492,7 @@ directive-value   = delta-seconds
 
         <p>In the case where a resource is embedded by a third party, the provider of the resource is often unable to instrument and observe the failure. For example, if `example.com` embeds a `widget.com/thing.js` resource on its site, and the user visiting `example.com` fails to fetch such resource due to a network error, the `widget.com` host is both unaware of the failure and unable to detect it.</p>
 
-        <p>To address this, `widget.com` can register an NEL policy for its host. Then, if such policy is present and a network error is encountered while fetching a resource &mdash; regardless of whether it is being requested from a first-party or third-party origin &mdash; from the registered <a>NEL host</a>, the user agent will report the network error and enable the provider to investigate the error.</p>
+        <p>To address this, `widget.com` can register an NEL policy for its host. Then, if such policy is present and a network error is encountered while fetching a resource &mdash; regardless of whether it is being requested from a first-party or third-party origin &mdash; from the registered <a>NEL origin</a>, the user agent will report the network error and enable the provider to investigate the error.</p>
       </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@ directive-value   = delta-seconds
         </section>
         <section>
           <h2>The `includeSubDomains` Directive</h2>
-          <p>The OPTIONAL <dfn>includeSubDomains</dfn> directive is a valueless directive that, if present, signals the user agent that the <a>NEL policy</a> applies to this <a>NEL host</a> as well as any subdomains of the host's domain name.</p>
+          <p>The OPTIONAL <dfn>includeSubDomains</dfn> directive is a valueless directive that, if present, signals the user agent that the <a>NEL policy</a> applies not only to the <a href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> that served the <a href="https://tools.ietf.org/html/rfc7231#section-3">resource representation</a>, but also to any <a href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> whose <a href="https://url.spec.whatwg.org/#concept-url-host">host</a> component is a subdomain of the <a href="https://url.spec.whatwg.org/#concept-url-host">host</a> component of the <a href="https://tools.ietf.org/html/rfc7231#section-3">resource representation</a>’s <a href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>.</p>
         </section>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -497,6 +497,21 @@ directive-value   = delta-seconds
     </section>
 
     <section>
+      <h2>Privacy Considerations</h2>
+
+      <p><a>NEL</a> provides network error reports that could expose new information about the user's network configuration. For example, an attacker could abuse NEL reporting to probe users network configuration. Also, similar to HSTS, HPKP, and pinned CSP policies, the stored <a>NEL policy</a> could be used as a "supercookie" by setting a distinct policy with a custom (per-user) reporting URI to act as an identififer in combination with (or instead of) HTTP cookies.</p>
+
+      <p>To mitigate some of the above risks, NEL registration is restricted to <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">trustworthy origins</a>, and delivery of network error reports is similarly restricted to <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">trustworthy origins</a>. This disallows a transient HTTP MITM from trivially abusing NEL as a persistent tracker.</p>
+
+      <p>In addition to above restrictions, the user agents MUST:<p>
+
+      <ul>
+        <li>Clear the stored NEL policies when the user clears their browsing data (cookies, site data, history, etc).</li>
+        <li>Refuse to process Set-Cookie response headers when delivering network error reports.</li>
+      </ul>
+    </section>
+
+    <section>
       <h2>IANA Considerations</h2>
       <p>... TODO ...</p>
     </section>


### PR DESCRIPTION
Addresses security and privacy issues raised in #42, #45.