### PR TITLE
Require 4xx and 5xx results to be `http.error`

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,8 @@
         <dd>
           <p>The following terms are defined in the HTTP specification: [[!RFC7231]]</p>
           <ul>
-            <li><dfn data-cite="!RFC7231#section-6.6">5xx status code</dfn></li>
+            <li><dfn data-lt="4xx" data-cite="!RFC7231#section-6.5">4xx status code</dfn></li>
+            <li><dfn data-lt="5xx" data-cite="!RFC7231#section-6.6">5xx status code</dfn></li>
             <li><dfn data-cite="!RFC7231#section-3">resource representation</dfn></li>
             <li><dfn data-cite="!RFC7231#section-6">status code</dfn></li>
           </ul>
@@ -235,10 +236,11 @@
       </ul>
 
       <p>
-      The user agent MAY classify and report server error responses (<a>5xx
-        status code</a>) as network errors. For example, a network error report
-      may be triggered when a fetch fails due to proxy or gateway errors,
-      service downtime, and other types of server errors.
+      The user agent MUST classify and report HTTP error responses (i.e., those
+      with a <a>4xx</a> or <a>5xx</a> status code) as network errors. For
+      example, a network error report must be triggered when a fetch fails due
+      to proxy or gateway errors, service downtime, and other types of client or
+      server errors.
       </p>
 
       <p>
@@ -249,11 +251,11 @@
 
       <p class="note">
       Note that the above definition of "network error" is different from
-      definition in [[Fetch]]. The definition of <a>network error</a> in this
-      specification is a subset of [[Fetch]] definition – i.e. all of the above
-      conditions would trigger a "network error" in [[Fetch]] processing, but
-      conditions such as blocked requests due to mixed content, CORS failures,
-      etc., would not.
+      definition in [[FETCH]].  For example, <a>4xx</a> and <a>5xx</a> status
+      codes are not considered a "network error" by [[FETCH]], but here are
+      considered a <a>network error</a> with a type <code>http.error</code>.
+      Other conditions, such as blocked requests due to mixed content or CORS
+      failures, are considered "network errors" by [[FETCH]], but not by NEL.
       </p>
 
       <p>
@@ -370,6 +372,9 @@
 
         </dl>
         <dl class='reportTypeGroup'>
+          <dt>http.error</dt>
+          <dd>The HTTP response had a <a>4xx</a> or <a>5xx</a> status code</dd>
+
           <dt>http.protocol.error</dt>
           <dd>The connection was aborted due to an HTTP protocol error</dd>
 

--- a/index.html
+++ b/index.html
@@ -171,10 +171,9 @@
         <dd>
           <p>The following terms are defined in the HTTP specification: [[!RFC7230]], [[!RFC7231]], [[!RFC7234]]</p>
           <ul>
+            <li><dfn data-cite="!RFC7231#section-6.3.1" data-lt="200 response">200 status code</dfn></li>
             <li><dfn data-cite="!RFC7231#section-6.5" data-lt="4xx">4xx status code</dfn></li>
             <li><dfn data-cite="!RFC7231#section-6.6" data-lt="5xx">5xx status code</dfn></li>
-            <li><dfn data-cite="!RFC7231#section-6.3.1" data-lt="200 response">200 status code</dfn></li>
-            <li><dfn data-cite="!RFC7231#section-6.6">5xx status code</dfn></li>
             <li><dfn data-cite="!RFC7234">local cache</dfn></li>
             <li><dfn data-cite="!RFC7230#section-6.3">persistent connections</dfn></li>
             <li><dfn data-cite="!RFC7230#section-2.1" data-lt="requests">request</dfn></li>
@@ -270,14 +269,6 @@
       </p>
 
       <p>
-      The user agent MUST classify and report HTTP error responses (i.e., those
-      with a <a>4xx</a> or <a>5xx</a> status code) as network errors. For
-      example, a network error report must be triggered when a fetch fails due
-      to proxy or gateway errors, service downtime, and other types of client or
-      server errors.
-      </p>
-
-      <p>
       A <a>request</a> MUST NOT result in a <a>network request</a> if the user
       agent is known to be offline (i.e., when <a>navigator.onLine</a> returns
       <code>false</code>).
@@ -340,12 +331,20 @@
       <p>
       A <a>network request</a> is <dfn
         data-lt="succeed|succeeded">successful</dfn> if the user agent is able
-      to receive a valid HTTP response from the server.
+      to receive a valid HTTP response from the server, and that response does
+      not have a <a>4xx</a> or <a>5xx</a> status code.
       </p>
 
       <p>
-      A <a>network request</a> is <dfn data-lt="fail">failed</dfn> if it is not
-      <a>successful</a>.
+      A <a>network request</a> is <dfn data-lt="fail|failures">failed</dfn> if
+      it is not <a>successful</a>.
+      </p>
+
+      <p class="note">
+      Note that HTTP error responses (i.e., those with a <a>4xx</a> or
+      <a>5xx</a> status code) are considered <a>failures</a>, so that they are
+      subject to a <a>NEL policy</a>'s <a>failure sampling rate</a> instead of
+      its <a>successful sampling rate</a>.
       </p>
     </section>
 
@@ -1136,7 +1135,10 @@
 
       <dl>
         <dt><code>http.error</code></dt>
-        <dd>The HTTP response had a <a>4xx</a> or <a>5xx</a> status code</dd>
+        <dd>
+        The user agent successfully received a response, but it had a <a>4xx</a>
+        or <a>5xx</a> status code
+        </dd>
 
         <dt><code>http.protocol.error</code></dt>
         <dd>The connection was aborted due to an HTTP protocol error</dd>


### PR DESCRIPTION
This would address #72.  The Chrome implementation already does this, but I don't have a strong opinion either way, since we could always translate `ok` → `http.error` on the collector side, too.  I think we should get rid of the current language (5xx MAY be an error) either way — it should either always be considered an error, or always be considered a success.