### PR TITLE
Factor out a Concepts section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
   <script class='remove'>
   var respecConfig = {
-    wg: "Web Platform Incubator Community Group",
-    wgURI: "https://www.w3.org/community/wicg/",
+    wg: "Web Performance Working Group",
+    wgURI: "https://www.w3.org/webperf/",
     shortName: "network-error-logging",
     specStatus: "CG-DRAFT",
     edDraftURI: "https://wicg.github.io/network-error-logging/",
@@ -160,11 +160,11 @@
         </dd>
         <dt>HTTP</dt>
         <dd>
-          <p>The following terms are defined in the HTTP specification: [[!RFC7230]], [[!RFC7231]], [[RFC7234]]</p>
+          <p>The following terms are defined in the HTTP specification: [[!RFC7230]], [[!RFC7231]], [[!RFC7234]]</p>
           <ul>
             <li><dfn data-cite="!RFC7231#section-6.3.1" data-lt="200 response">200 status code</dfn></li>
             <li><dfn data-cite="!RFC7231#section-6.6">5xx status code</dfn></li>
-            <li><dfn data-cite="RFC7234">local cache</dfn></li>
+            <li><dfn data-cite="!RFC7234">local cache</dfn></li>
             <li><dfn data-cite="!RFC7230#section-2.1" data-lt="requests">request</dfn></li>
             <li><dfn data-cite="!RFC7231#section-4">request method</dfn></li>
             <li><dfn data-cite="!RFC7231#section-3">resource representation</dfn></li>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
   <script class='remove'>
   var respecConfig = {
+    wg: "Web Platform Incubator Community Group",
+    wgURI: "https://www.w3.org/community/wicg/",
     shortName: "network-error-logging",
     specStatus: "CG-DRAFT",
     edDraftURI: "https://wicg.github.io/network-error-logging/",
@@ -86,7 +88,7 @@
 
     <p>Existing methods (such as synthetic monitoring) provide a partial solution by placing monitoring nodes in predetermined geographic locations, but require additional infrastructure investments, and cannot provide truly global and near real-time availability data for real end users.</p>
 
-    <p>Network Error Logging (<dfn>NEL</dfn>) addresses this need by defining a mechanism enabling web applications to declare a reporting policy that can be used by the user agent to report network errors for a given origin. To take advantage of <a>NEL</a>, a web application opts into using <a>NEL</a> by supplying a <code>NEL</code> HTTP response header field that describes the reporting policy. Then, if the <a>NEL</a> policy is available for a given origin, the user agent logs information about requests to that origin, and attempts to deliver that information to a group of endpoints previously configured using the Reporting API [[!REPORTING]].  As the name implies, <a>NEL</a> reports are primarily used to describe <em>errors</em>. However, in order to determine <em>rates</em> of errors across different client populations, we must also know how many <em>successful</em> requests are occurring; these successful requests can also be reported via the <a>NEL</a> mechanism.</p>
+    <p>Network Error Logging (NEL) addresses this need by defining a mechanism enabling web applications to declare a reporting policy that can be used by the user agent to report network errors for a given origin.  A web application opts into using NEL by supplying a <a>NEL</a> HTTP response header field that describes the desired <a>NEL policy</a>. This policy instructs the user agent to log information about requests to that origin, and to attempt to deliver that information to a group of endpoints previously configured using the Reporting API [[!REPORTING]].  As the name implies, NEL reports are primarily used to describe <em>errors</em>. However, in order to determine <em>rates</em> of errors across different client populations, we must also know how many <em>successful</em> requests are occurring; these successful requests can also be reported via the NEL mechanism.</p>
 
     <p>For example, if the user agent fails to fetch a resource from <code>https://www.example.com</code> due to an aborted TCP connection, the user agent would queue the following report via the Reporting API:</p>
 
@@ -112,9 +114,10 @@
     </dl>
 
     <p>
-    See <a href="#network-error-reports"></a> for explanation of the
-    communicated fields and format of the report, and <a href="#examples"></a>
-    for more hands-on examples of NEL registration and reporting process.
+    See <a href="#generate-a-network-error-report"></a> for an explanation of
+    the communicated fields and format of the report, and <a
+      href="#examples"></a> for more hands-on examples of NEL registration and
+    reporting process.
     </p>
   </section>
 
@@ -133,24 +136,41 @@
           <p>The following terms are defined in the Fetch specification: [[!FETCH]]</p>
           <ul>
             <li><dfn data-cite="!FETCH#concept-request-client">client</dfn></li>
+            <li><dfn data-cite="!FETCH#cors-preflight-request">CORS-preflight request</dfn></li>
+            <li><dfn data-cite="!FETCH#http-network-fetch">HTTP-network fetch</dfn></li>
+            <li><dfn data-cite="!FETCH#http-network-or-cache-fetch">HTTP-network-or-cache fetch</dfn></li>
+            <li><dfn data-cite="!FETCH#redirect-status" data-lt="redirects">redirect status</dfn></li>
+          </ul>
+        </dd>
+        <dt>HSTS</dt>
+        <dd>
+          <p>The following terms are defined in the HSTS specification: [[!RFC6797]]</p>
+          <ul>
+            <li><dfn data-cite="!RFC6797#section-8.2">superdomain match</dfn></li>
           </ul>
         </dd>
         <dt>HTML</dt>
         <dd>
           <p>The following terms are defined in the HTML specification: [[!HTML]]</p>
           <ul>
+            <li><dfn data-cite="!HTML#navigate" data-lt="navigation">navigate</dfn></li>
             <li><dfn data-cite="!HTML#navigator.online"><code>navigator.onLine</code></dfn></li>
-            <li>resource <dfn data-cite="!HTML#origin">origin</dfn></li>
+            <li>resource <dfn data-cite="!HTML#origin" data-lt="origins">origin</dfn></li>
           </ul>
         </dd>
         <dt>HTTP</dt>
         <dd>
-          <p>The following terms are defined in the HTTP specification: [[!RFC7231]]</p>
+          <p>The following terms are defined in the HTTP specification: [[!RFC7230]], [[!RFC7231]], [[RFC7234]]</p>
           <ul>
             <li><dfn data-cite="!RFC7231#section-6.3.1" data-lt="200 response">200 status code</dfn></li>
             <li><dfn data-cite="!RFC7231#section-6.6">5xx status code</dfn></li>
+            <li><dfn data-cite="RFC7234">local cache</dfn></li>
+            <li><dfn data-cite="!RFC7230#section-2.1" data-lt="requests">request</dfn></li>
             <li><dfn data-cite="!RFC7231#section-4">request method</dfn></li>
             <li><dfn data-cite="!RFC7231#section-3">resource representation</dfn></li>
+            <li><dfn data-cite="!RFC7230#section-2.1" data-lt="responses">response</dfn></li>
+            <li><dfn data-cite="!RFC7231#section-7" data-lt="response header">response headers</dfn></li>
+            <li><dfn data-cite="!RFC7230#section-2.1">server</dfn></li>
             <li><dfn data-cite="!RFC7231#section-6">status code</dfn></li>
           </ul>
         </dd>
@@ -180,6 +200,8 @@
           <p>The following terms are defined in the Reporting API specification: [[!REPORTING]]</p>
           <ul>
             <li><dfn data-cite="!REPORTING#endpoint-group">endpoint group</dfn></li>
+            <li><dfn data-cite="!REPORTING#report" data-lt="reports">report</dfn></li>
+            <li><dfn data-cite="!REPORTING#report-body">report body</dfn></li>
             <li><dfn data-cite="!REPORTING#report-type">report type</dfn></li>
           </ul>
         </dd>
@@ -212,293 +234,583 @@
   </section>
 
   <section>
-    <h2>Network Error Logging</h2>
+    <h2>Concepts</h2>
 
     <section>
-      <h2>Network error reports</h2>
+      <h2>Network requests</h2>
 
       <p>
-      A <dfn data-lt="network error|network error reports">network error
-        report</dfn> describes whether or not the user agent encountered any
-      connection or protocol error while handling a network request, thus
-      preventing it from successfully completing the request-response exchange.
-      This may include, but is not limited to DNS, TCP, TLS, and HTTP connection
-      and protocol errors. For example, a network error is triggered when the
-      user agent:
-      </p>
-
-      <ul>
-        <li>Fails to resolve the DNS name</li>
-        <li>Fails to establish a TCP connection</li>
-        <li>Fails to establish a secure TLS tunnel</li>
-        <li>Fails to fetch the resource due to a TLS protocol error</li>
-        <li>Fails to fetch the resource due to a HTTP protocol error</li>
-        <li>Fails to fetch the resource due to a socket timeout or error</li>
-        <li>Fails to fetch the resource due to a redirect loop</li>
-      </ul>
-
-      <p>
-      The user agent MAY classify and report server error responses (<a>5xx
-        status code</a>) as network errors. For example, a network error report
-      may be triggered when a fetch fails due to proxy or gateway errors,
-      service downtime, and other types of server errors.
+      A <dfn data-lt="network requests">network request</dfn> occurs when the
+      user agent must use the network to service a single <a>request</a>.
       </p>
 
       <p>
-      The failure to fetch a resource when the user agent is known to be offline
-      (when <a>navigator.onLine</a> returns <code>false</code>) MUST NOT be
-      considered to be a <a>network error</a>.
+      If the user agent can service a <a>request</a> out of a <a>local
+        cache</a>, that <a>request</a> MUST NOT result in a <a>network
+        request</a>.
+      </p>
+
+      <p>
+      If the user agent follows <a>redirects</a> as part of a <a>navigation</a>,
+      there MUST be separate <a>network requests</a> for each <a>request</a> in
+      the redirect chain.
+      </p>
+
+      <p>
+      A <a>request</a> MUST NOT result in a <a>network request</a> if the user
+      agent is known to be offline (i.e., when <a>navigator.onLine</a> returns
+      <code>false</code>).
+      </p>
+
+      <p>
+      A <a>request</a> MUST NOT result in a <a>network request</a> if it is
+      blocked due to mixed content or CORS failures.  Any <a>CORS-preflight
+        request</a> MUST result in its own <a>network request</a>.
       </p>
 
       <p class="note">
-      Note that the above definition of "network error" is different from
-      definition in [[Fetch]]. The definition of <a>network error</a> in this
-      specification is a subset of [[Fetch]] definition – i.e. all of the above
-      conditions would trigger a "network error" in [[Fetch]] processing, but
-      conditions such as blocked requests due to mixed content, CORS failures,
-      etc., would not.
+      For user agents that service <a>requests</a> according to the [[FETCH]]
+      standard, a <a>network request</a> corresponds to one execution of the
+      <a>HTTP-network fetch</a> algorithm.
       </p>
 
       <p>
-      <a>Network error reports</a> have a <a>report type</a> of
-      <code>network-error</code>.
+      A <a>network request</a> is <dfn
+        data-lt="succeed|succeeded">successful</dfn> if the user agent is able
+      to receive a valid HTTP response from the server.
       </p>
 
       <p>
-      A <a>network error report</a>'s <dfn data-lt="network error report
-        body">body</dfn> contains the following fields:
+      A <a>network request</a> is <dfn data-lt="fail">failed</dfn> if it is not
+      <a>successful</a>.
       </p>
-
-      <dl>
-        <dt><dfn data-lt="report-uri"><code>uri</code></dfn></dt>
-        <dd>The URL of the request, with any <a>fragment</a> component removed.</dd>
-
-        <dt><dfn data-lt="report-referrer"><code>referrer</code></dfn></dt>
-        <dd>The referrer information of the request, as determined by the <a>referrer policy</a> associated with its <a>client</a>.</dd>
-
-        <dt><dfn data-lt="report-sampling-fraction"><code>sampling_fraction</code></dfn></dt>
-        <dd>The <a>active sampling rate</a> for this request.</dd>
-
-        <dt><dfn data-lt="report-server-ip"><code>server_ip</code></dfn></dt>
-        <dd>The IP address of the host to which the user agent sent the request, if available. Otherwise, an empty string.
-        <ul>
-          <li>A host identified by an IPv4 address is represented in dotted-decimal notation (a sequence of four decimal numbers in the range 0 to 255, separated by "."). [[RFC1123]]</li>
-          <li>A host identified by an IPv6 address is represented as an ordered list of eight 16-bit pieces (a sequence of `x:x:x:x:x:x:x:x`, where the 'x's are one to four hexadecimal digits of the eight 16-bit pieces of the address). [[RFC4291]] </li>
-        </ul>
-        </dd>
-
-        <dt><dfn data-lt="report-protocol"><code>protocol</code></dfn></dt>
-        <dd>The <a>network protocol</a>  used to fetch the resource as identified by the ALPN Protocol ID, if available. Otherwise, an empty string.</dd>
-
-        <dt><dfn data-lt="report-method"><code>method</code></dfn></dt>
-        <dd>The <a>request method</a> of the HTTP request.</dd>
-
-        <dt><dfn data-lt="report-status-code"><code>status_code</code></dfn></dt>
-        <dd>The <a>status code</a> of the HTTP response, if available. Otherwise, the number 0.</dd>
-
-        <dt><dfn data-lt="report-elapsed-time"><code>elapsed_time</code></dfn></dt>
-        <dd>The elapsed number of milliseconds between the start of the resource fetch and when it was aborted by the user agent.</dd>
-
-        <dt><dfn data-lt="report-type"><code>type</code></dfn></dt>
-        <dd>The description of the error type, which SHOULD be one the following strings:
-
-        <dl class='reportTypeGroup'>
-          <dt>ok</dt>
-          <dd>The request did <em>not</em> result in a <a>network error</a></dd>
-        </dl>
-        <dl class='reportTypeGroup'>
-          <dt>dns.unreachable</dt>
-          <dd>DNS server is unreachable</dd>
-
-          <dt>dns.name_not_resolved</dt>
-          <dd>DNS server responded but is unable to resolve the address</dd>
-          <dt>dns.failed</dt>
-          <dd>Request to the DNS server failed due to reasons not covered by previous errors</dd>
-
-        </dl>
-        <dl class='reportTypeGroup'>
-          <dt>tcp.timed_out</dt>
-          <dd>TCP connection to the server timed out</dd>
-
-          <dt>tcp.closed</dt>
-          <dd>The TCP connection was closed by the server</dd>
-
-          <dt>tcp.reset</dt>
-          <dd>The TCP connection was reset</dd>
-
-          <dt>tcp.refused</dt>
-          <dd>The TCP connection was refused by the server</dd>
-
-          <dt>tcp.aborted</dt>
-          <dd>The TCP connection was aborted</dd>
-
-          <dt>tcp.address_invalid</dt>
-          <dd>The IP address is invalid</dd>
-
-          <dt>tcp.address_unreachable</dt>
-          <dd>The IP address is unreachable</dd>
-
-          <dt>tcp.failed</dt>
-          <dd>The TCP connection failed due to reasons not covered by previous errors</dd>
-
-
-        </dl>
-        <dl class='reportTypeGroup'>
-          <dt>tls.version_or_cipher_mismatch</dt>
-          <dd>The TLS connection was aborted due to version or cipher mismatch</dd>
-
-          <dt>tls.bad_client_auth_cert</dt>
-          <dd>The TLS connection was aborted due to invalid client certificate</dd>
-
-          <dt>tls.cert.name_invalid</dt>
-          <dd>The TLS connection was aborted due to invalid name</dd>
-
-          <dt>tls.cert.date_invalid</dt>
-          <dd>The TLS connection was aborted due to invalid certificate date</dd>
-
-          <dt>tls.cert.authority_invalid</dt>
-          <dd>The TLS connection was aborted due to invalid issuing authority</dd>
-
-          <dt>tls.cert.invalid</dt>
-          <dd>The TLS connection was aborted due to invalid certificate</dd>
-
-          <dt>tls.cert.revoked</dt>
-          <dd>The TLS connection was aborted due to revoked server certificate</dd>
-
-          <dt>tls.cert.pinned_key_not_in_cert_chain</dt>
-          <dd>The TLS connection was aborted due to a key pinning error</dd>
-
-          <dt>tls.protocol.error</dt>
-          <dd>The TLS connection was aborted due to a TLS protocol error</dd>
-
-          <dt>tls.failed</dt>
-          <dd>The TLS connection failed due to reasons not covered by previous errors</dd>
-
-        </dl>
-        <dl class='reportTypeGroup'>
-          <dt>http.protocol.error</dt>
-          <dd>The connection was aborted due to an HTTP protocol error</dd>
-
-          <dt>http.response.invalid</dt>
-          <dd>Response is empty, has a content-length mismatch, has improper encoding, and/or other conditions that prevent user agent from processing the response</dd>
-
-          <dt>http.response.redirect_loop</dt>
-          <dd>The request was aborted due to a detected redirect loop</dd>
-
-          <dt>http.failed</dt>
-          <dd>The connection failed due to errors in HTTP protocol not covered by previous errors</dd>
-
-        </dl>
-        <dl class='reportTypeGroup'>
-          <dt>abandoned</dt>
-          <dd>User aborted the resource fetch before it is complete</dd>
-
-          <dt>unknown</dt>
-          <dd>error type is unknown</dd>
-        </dl>
-
-        <p>
-        The user agent MAY extend the above error type list with custom values —
-        e.g. new error types to accommodate new protocols, or more detailed
-        error descriptions of existing ones. When doing so, the user agent
-        SHOULD follow the dot-delimited pattern
-        (<code>[group].[optional-subgroup].[error-name]</code>) to facilitate
-        simple and consistent processing of the error reports — e.g. the
-        collector may provide aggregation by category and/or one or multiple
-        subgroups.
-        </p>
-        </dd>
-      </dl>
     </section>
 
     <section>
-      <h2>Policy Delivery and Processing</h2>
-      <p>The server delivers the <a>NEL policy</a> to the user agent via an HTTP response header field (<a>NEL header field</a>). If the result of executing the <a>is-origin-trustworthy</a> algorithm on the <a>origin</a> that served the <a>NEL policy</a> is <code>Potentially Trustworthy</code> then the user agent MUST either:</p>
+      <h2>Network errors</h2>
+
+      <p>
+      A <dfn data-lt="network errors">network error</dfn> is the error condition
+      that caused a <a>network request</a> to <a>fail</a>.
+      </p>
+
+      <p>
+      Each <a>network error</a> has a <dfn data-lt="types">type</dfn>, which is
+      a string.
+      </p>
+
+      <p>
+      There are several predefined <a>network error</a> <a>types</a> defined in
+        <a href="#predefined-network-error-types"></a>.
+      </p>
+    </section>
+
+    <section>
+      <h2>NEL policies</h2>
+
+      <p>
+      A <dfn data-lt="NEL policies">NEL policy</dfn> instructs a user agent
+      whether to collect reports about <a>network requests</a> to an
+      <a>origin</a>, and if so, where to send them.  <a>NEL policies</a> are
+      delivered to the user agent via HTTP <a>response headers</a>.
+      </p>
+
+      <p>
+      Each <a>NEL policy</a> has an <dfn data-lt-nodefault data-lt="policy
+        origin">origin</dfn>.
+      </p>
+
+      <p>
+      Each <a>NEL policy</a> has a <dfn>subdomains</dfn> flag, which is either
+      <code>include</code> or <code>exclude</code>.
+      </p>
+      <p>
+
+      <p>
+      Each <a>NEL policy</a> has a <dfn>reporting group</dfn>, which is the name
+      of the Reporting <a>endpoint group</a> that reports for this policy will
+      be sent to.
+      </p>
+
+      <p>
+      Each <a>NEL policy</a> has a <dfn>ttl</dfn> representing the number of
+      seconds the policy remains valid.
+      </p>
+
+      <p>
+      Each <a>NEL policy</a> has a <dfn>creation</dfn> which is the timestamp
+      when the user agent received the policy.
+      </p>
+
+      <p>
+      A <a>NEL policy</a> is <dfn>expired</dfn> if its <a>creation</a> plus its
+      <a>ttl</a> represents a time in the past.
+      </p>
+    </section>
+
+    <section>
+      <h2>Sampling rates</h2>
+
+      <p>
+      An <a>origin</a> that expects to serve a large volume of traffic might not
+      be equipped to ingest NEL reports for every <a>network request</a> made to
+      the origin.  The origin can define <dfn data-lt="sampling rate">sampling
+        rates</dfn> to limit the number of NEL reports that each user agent
+      submits.  Since <a>successful</a> requests should typically greatly
+      outnumber <a>failed</a> requests, the origin can specify different
+      sampling rates for each.
+      </p>
+
+      <p>
+      Each <a>NEL policy</a> has a <dfn>successful sampling rate</dfn>, which is
+      a number between 0.0 and 1.0 inclusive.
+      </p>
+
+      <p>
+      Each <a>NEL policy</a> has a <dfn>failure sampling rate</dfn>, which is a
+      number between 0.0 and 1.0 inclusive.
+      </p>
+    </section>
+
+    <section>
+      <h2>Policy cache</h2>
+
+      <p>
+      A conformant user agent MUST provide a <dfn>policy cache</dfn>, which is a
+      storage mechanism that maintains a set of <a>NEL policies</a>, keyed by
+      their <a data-lt="policy origin">origins</a>.
+      </p>
+
+      <p>
+      This storage mechanism is opaque, vendor-specific, and not exposed to the
+      web, but it MUST provide the following methods which will be used in the
+      algorithms this document defines:
+      </p>
 
       <ul>
-        <li>Register the host as a <a>known NEL origin</a> if it is not already registered.</li>
-        <li>Update the registered policy for the <a>known NEL origin</a> if the provided policy is different than that already stored by the user agent.</li>
+        <li>Insert, update, and delete <a>NEL policies</a>.</li>
+        <li>Retrieve the <a>NEL policy</a>, if any, for an <a>origin</a>.</li>
+        <li>Clear the cache.</li>
       </ul>
+    </section>
 
-      <p>Otherwise, if the result of the algorithm is <strong>not</strong> <code>Potentionally Trustworthy</code>, then the user MUST ignore the provided <a>NEL policy</a>.</p>
+  </section>
+
+  <section>
+    <h2>Policy delivery</h2>
+
+    <p>
+    A <a>server</a> MAY define a <a>NEL policy</a> for an origin it controls via
+    the <a>NEL</a> HTTP <a>response header</a>.
+    </p>
+
+    <section>
+      <h2><code>NEL</code> response header</h2>
+
+      <p>
+      The <dfn><code>NEL</code></dfn> <a>response header</a> is used to
+      communicate an <a>origin</a>'s <a>NEL policy</a> to the user agent.  The
+      ABNF (Augmented Backus-Naur Form) syntax for the <a>NEL</a> header is as
+      follows:
+      </p>
+
+      <pre>NEL = json-field-value</pre>
+
+      <p>
+      The header's value is interpreted as an array of JSON objects, as defined
+      by <a>json-field-value</a>. Each object in the array defines an <a>NEL
+        policy</a> for the origin. The user agent MUST process the first valid
+      policy in the array and ignore any additional policies in the array.
+      </p>
+
+      <p>User agents MUST ignore any unknown or invalid field(s) or value(s) that do not conform to the syntax defined in this specification. A valid <a>NEL</a> header field MUST, at a minimum, contain one object with all of the "REQUIRED" fields defined in this specification.</p>
+
+      <p>The user agent MUST ignore the <a>NEL</a> header specified via a <code>meta</code> element to mitigate hijacking of error reporting via scripting attacks. The <a>NEL policy</a> MUST be delivered via the <a>NEL</a> <a>response header</a>.</p>
+
+      <p class="note">The restriction on <code>meta</code> element is consistent with the [[CSP]] specification, which restricts reporting registration to HTTP header fields only for the same reasons.</p>
 
       <section>
-        <h2><code>NEL</code> Header Field</h2>
-        <p>The <dfn>NEL header field</dfn> is used to communicate the <dfn>NEL policy</dfn> to the user agent. The ABNF (Augmented Backus-Naur Form) syntax for the <a>NEL header field</a> is as follows:</p>
+        <h2>The <code>report_to</code> member</h2>
 
-        <pre>NEL = json-field-value</pre>
+        <p>
+        The <dfn><code>report_to</code></dfn> member specifies the <a>endpoint
+          group</a> that reports for this <a>NEL policy</a> will be sent to.
+        The <a>report_to</a> member is REQUIRED to register a <a>NEL policy</a>,
+        and OPTIONAL if the intent is to remove a previous registration – see
+        <a>max_age</a>.  If present, its value MUST be a string; any other type
+        will result in a parse error.
+        </p>
 
-        <p>The header's value is interpreted as an array of JSON objects, as defined by <a>json-field-value</a>. Each object in the array defines an <a>NEL policy</a> for the origin. The user agent MUST process the first valid policy in the array.</p>
+        <p class="note">
+        To improve delivery of NEL reports, the <a>server</a> should set
+        <code>report_to</code> to an <a>endpoint group</a> containing at least
+        one endpoint in an alternative origin whose infrastructure is not
+        coupled with the origin from which the resource is being fetched &mdash;
+        otherwise network errors cannot be reported until the problem is solved,
+        if ever &mdash; and provide multiple endpoints to provide alternatives
+        if some endpoints are unreachable.
+        </p>
+      </section>
 
-        <p>User agents MUST ignore any unknown or invalid field(s) or value(s) that do not conform to the syntax defined in this specification. A valid <a>NEL header field</a> MUST, at a minimum, contain one object with all of the "REQUIRED" fields defined in this specification.</p>
+      <section>
+        <h2>The <code>max_age</code> member</h2>
 
-        <p>The user agent MUST ignore the NEL header specified via a <code>meta</code> element to mitigate hijacking of error reporting via scripting attacks. The <a>NEL policy</a> MUST be delivered via the <a>NEL header field</a>.</p>
+        <p>
+        The REQUIRED <dfn><code>max_age</code></dfn> member specifies the
+        lifetime of this <a>NEL policy</a>, as a non-negative integer number of
+        seconds.  Its value MUST be an non-negative integer; any other type will
+        result in a parse error.
+        </p>
 
-        <p class="note">The restriction on <code>meta</code> element is consistent with the [[CSP]] specification, which restricts reporting registration to HTTP header fields only for the same reasons.</p>
+        <p>
+        A value of <code>0</code> will cause any <a>NEL policy</a> for this
+        <a>origin</a> to be removed from the <a>policy cache</a>.
+        </p>
 
-        <section>
-          <h2>The <code>report_to</code> Field</h2>
-          <p>The <dfn>report_to</dfn> field specifies the <a>endpoint group</a> to which the user agent sends reports about network errors. The <a>report_to</a> field is a REQUIRED field to register an <a>NEL policy</a>, and OPTIONAL if the intent is to remove a previous registration - see <a>max_age</a>. The value of the field MUST be a string containing the <a>endpoint group</a> to which reports will be sent.</p>
+        <p class="note">
+        To ensure delivery of NEL reports, the <a>server</a> should ensure that
+        the Reporting <a>endpoint group</a> is also configured with a
+        sufficiently high <code>max_age</code>.  If the Reporting policy
+        expires, NEL reports will not be delivered, even if the NEL policy has
+        not expired.
+        </p>
+      </section>
 
-          <p class="note">To improve delivery of NEL reports, the application should set <code>report_to</code> to an endpoint group containing at least one endpoint in an alternative origin whose infrastructure is not coupled with the origin from which the resource is being fetched &mdash; otherwise network errors cannot be reported until the problem is solved, if ever &mdash; and provide multiple endpoints to provide alternatives if some endpoints are unreachable.</p>
+      <section>
+        <h2>The <code>include_subdomains</code> member</h2>
 
-        </section>
-        <section>
-          <h2>The <code>max_age</code> Field</h2>
-          <p>The REQUIRED <dfn>max_age</dfn> field specifies the number of seconds, after the reception of the NEL header field, during which the user agent regards the host (from whom the policy was received) as a <a>known NEL origin</a>. The value of the field MUST be an non-negative integer.</p>
+        <p>
+        The OPTIONAL <dfn><code>include_subdomains</code></dfn> member is a
+        boolean that enables this <a>NEL policy</a> for all subdomains of this
+        origin.  If no member named <code>include_subdomains</code> is present
+        in the object, or its value is not <code>true</code>, the <a>NEL
+        policy</a> will not be enabled for subdomains.
+        </p>
 
-          <p>A <a>max_age</a> value of zero (i.e. <code>"max_age": 0</code>) signals the user agent to cease regarding the host as a <a>known NEL origin</a>, including the <a>include_subdomains</a> field if provided.</p>
+        <p class="note">
+        To ensure delivery of NEL reports for subdomains, the application should
+        ensure that the Reporting <a>endpoint group</a> is also configured with
+        <code>include_subdomains</code> enabled.  If the Reporting policy is
+        not, and there is not a separate Reporting policy for a given subdomain,
+        NEL reports for that subdomain will not be delivered, even if the NEL
+        policy includes the subdomain.
+        </p>
+      </section>
 
-          <p class="note">To ensure delivery of NEL reports, the application should ensure that the Reporting API is also configured with a sufficiently high <code>max_age</code>. If the Reporting policy expires, NEL reports will not be delivered, even if the NEL policy has not expired.</p>
-        </section>
-        <section>
-          <h2>The <code>include_subdomains</code> Field</h2>
-          <p>The OPTIONAL <dfn>include_subdomains</dfn> field, if present and true, signals the user agent that the <a>NEL policy</a> applies not only to the <a>origin</a> that served the <a>resource representation</a>, but also to any <a>origin</a> whose <a>host</a> component is a subdomain of the <a>host</a> component of the <a>resource representation</a>’s <a>origin</a>. If present, the value of the field MUST be a boolean value.</p>
+      <section>
+        <h2>The <code>success_fraction</code> member</h2>
 
-          <p class="note">To ensure delivery of NEL reports for subdomains, the application should ensure that the Reporting API is also configured with <code>include_subdomains</code> enabled. If the Reporting policy is not, and there is not a separate Reporting policy for a given subdomain, NEL reports for that subdomain will not be delivered, even if the NEL policy includes the subdomain.</p>
-        </section>
+        <p>
+        The OPTIONAL <dfn><code>success_fraction</code></dfn> member defines the
+        <a>sampling rate</a> that should be applied to reports about
+        <a>successful</a> <a>network requests</a> for this origin.  If present,
+        its value MUST be a number between <code>0.0</code> and
+        <code>1.0</code>, inclusive; any other value will result in a parse
+        error.  If this member is not present, the user agent will <em>not</em>
+        collect NEL reports about <a>successful</a> <a>network requests</a> for
+        this origin.
+        </p>
+      </section>
 
-        <section>
-          <h2>The <code>success_fraction</code> field</h2>
-          <p>The OPTIONAL <dfn>success_fraction</dfn> field defines the <a>sampling rate</a> that should be applied to reports about requests that do not result in a <a>network error</a>. If present, this field MUST have a value between <code>0.0</code> and <code>1.0</code>, inclusive. If this field is not present, it defaults to <code>0.0</code> — by default, the user agent will <em>not</em> collect NEL reports about successful requests unless specifically requested by the origin.</p>
-        </section>
+      <section>
+        <h2>The <code>failure_fraction</code> member</h2>
 
-        <section>
-          <h2>The <code>failure_fraction</code> field</h2>
-          <p>The OPTIONAL <dfn>failure_fraction</dfn> field defines the <a>sampling rate</a> that should be applied to reports about requests that result in a <a>network error</a>. If present, this field MUST have a value between <code>0.0</code> and <code>1.0</code>, inclusive. If this field is not present, it defaults to <code>1.0</code> — by default, the user agent will collect NEL reports about <em>all</em> requests that result in a <a>network error</a>.</p>
-        </section>
+        <p>
+        The OPTIONAL <dfn><code>failure_fraction</code></dfn> member defines the
+        <a>sampling rate</a> that should be applied to reports about
+        <a>failed</a> <a>network requests</a> for this origin.  If present, its
+        value MUST be a number between <code>0.0</code> and <code>1.0</code>,
+        inclusive; any other value will result in a parse error.  If this member
+        is not present, the user agent will collect NEL reports about
+        <em>all</em> <a>failed</a> <a>network requests</a> for this origin.
+        </p>
       </section>
     </section>
 
     <section>
-      <h2>Policy Storage and Maintenance</h2>
-
-      <p>An HTTP host declares itself an <dfn>NEL origin</dfn> by issuing an <a>NEL policy</a>, which is communicated via the <a>NEL header field</a> from a <a>potentially trustworthy origin</a>. Upon error-free receipt and processing of this header by a conformant user agent, the user agent regards the host as a <dfn>known NEL origin</dfn>.</p>
-
-      <p>The user agent MUST maintain the <a>NEL policy</a> of any given <a>NEL origin</a> separately from any NEL policies issued by any other <a data-lt="NEL origin">NEL origins</a>. Only the given <a>NEL origin</a> can update or cause deletion of its <a>NEL policy</a>. This is accomplished by sending a <a>NEL header field</a> to the user agent with new values for the policy <a data-lt="report_to">endpoint group</a>, <a data-lt="max_age">time duration</a>, and <a data-lt="include_subdomains">subdomain applicability</a>. Thus, the user agent MUST store the "freshest" <a>NEL policy</a> information on behalf of an <a>NEL origin</a>, and specifying a zero time duration MUST cause the user agent to delete the <a>NEL policy</a> (including any asserted <a>include_subdomains</a> field) for that <a>NEL origin</a>.</p>
-    </section>
-
-    <section>
-      <h2>Generating reports</h2>
+      <h2>Process policy headers</h2>
 
       <p>
-      When a request is made to a URL that belongs to a <a>known NEL origin</a>
-      the user agent MUST use an algorithm equivalent to the following to decide
-      whether to generate and upload a <a>network error report</a> for the
-      request:
+      Given a <a>network request</a> (<var>request</var>) and its corresponding
+      <a>response</a> (<var>response</var>), this algorithm extracts a <a>NEL
+        policy</a> for <var>request</var>'s <a>origin</a>, and updates the
+      <a>policy cache</a> accordingly.
       </p>
 
       <ol>
-        <li>Determine the <dfn>active sampling rate</dfn> for this request:
+        <li>
+          Abort these steps if any of the following conditions are true:
+
           <ul>
-            <li>If the request resulted in a <a>network error</a>, then the active sampling rate is the value of the <a><code>failure_fraction</code></a> field in the origin's <a>NEL policy</a>, or <code>1.0</code> if the <a>NEL policy</a> does not contain a <a><code>failure_fraction</code></a> field.</li>
-            <li>If the request did <em>not</em> result in a <a>network error</a>, then the active sampling rate is the value of the <a><code>success_fraction</code></a> field in the origin's <a>NEL policy</a>, or <code>0.0</code> if the <a>NEL policy</a> does not contain a <a><code>success_fraction</code></a> field.</li>
+            <li>
+              The result of executing the <a>is-origin-trustworthy</a> algorithm
+              on <var>request</var>'s <a>origin</a> is <strong>not</strong>
+              <code>Potentially Trustworthy</code>.
+            </li>
+
+            <li>
+              <var>response</var> does not contain a <a>response header</a>
+              whose name is <code>NEL</code>.
+            </li>
           </ul>
         </li>
 
-        <li>Decide whether or not to report on this request. Choose a random number between 0.0 and 1.0, inclusive. If this number is greater than or equal to the <a>active sampling rate</a> for this request, ignore the request and skip the remainder of this algorithm.</li>
+        <li>
+          Let <var>origin</var> be <var>request</var>'s <a>origin</a>.
+        </li>
 
-        <li>Construct a <a>network error report</a> for the request.</li>
+        <li>
+          Let <var>header</var> be the value of the <a>response header</a> whose
+          name is <code>NEL</code>.
+        </li>
+
+        <li>
+          Let <var>list</var> be the result of executing the algorithm defined
+          in Section 4 of [[HTTP-JFV]] on <var>header</var>.  If that algorithm
+          results in an error, or if <var>list</var> is empty, abort these
+          steps.
+        </li>
+
+        <li>
+          Let <var>item</var> be the first element of <var>list</var>.
+        </li>
+
+        <li>
+          If <var>item</var> has no member named <a>max_age</a>, or that
+          member's value is not a number, abort these steps.
+        </li>
+
+        <li>
+          If the value of <var>item</var>'s <a>max_age</a> member is
+          <code>0</code>, then remove any <a>NEL policy</a> from the <a>policy
+            cache</a> whose <a data-lt="policy origin">origin</a> is
+          <var>origin</var>, and skip the remaining steps.
+        </li>
+
+        <li>
+          If <var>item</var> has no member named <a>report_to</a>, or that
+          member's value is not a string, abort these steps.
+        </li>
+
+        <li>
+          If <var>item</var> has a member named <a>success_fraction</a>, whose
+          value is not a number in the range 0.0 to 1.0, inclusive, abort these
+          steps.
+        </li>
+
+        <li>
+          If <var>item</var> has a member named <a>failure_fraction</a>, whose
+          value is not a number in the range 0.0 to 1.0, inclusive, abort these
+          steps.
+        </li>
+
+        <li>
+          <p>
+          Let <var>policy</var> be a new <a>NEL policy</a> whose properties are
+          set as follows:
+          </p>
+
+          <dl>
+            <dt><a>origin</a></dt>
+            <dd><var>origin</var></dd>
+
+            <dt><a>subdomains</a> flag</dt>
+            <dd>
+            <code>include</code> if <var>item</var> has a member named
+            <a>include_subdomains</a> whose value is <code>true</code>,
+            <code>exclude</code> otherwise
+            </dd>
+
+            <dt><a>reporting group</a></dt>
+            <dd>the value of <var>item</var>'s <a>report_to</a> member</dd>
+
+            <dt><a>ttl</a></dt>
+            <dd>the value of <var>item</var>'s <a>max_age</a> member</dd>
+
+            <dt><a>creation</a></dt>
+            <dd>the current timestamp</dd>
+
+            <dt><a>successful sampling rate</a></dt>
+            <dd>
+            the value of <var>item</var>'s <a>success_fraction</a> member, if
+            present; <code>0.0</code> otherwise
+            </dd>
+
+            <dt><a>failure sampling rate</a></dt>
+            <dd>
+            the value of <var>item</var>'s <a>failure_fraction</a> member, if
+            present; <code>1.0</code> otherwise
+            </dd>
+          </dl>
+        </li>
+
+        <li>
+          If there is already an entry in the <a>policy cache</a> for
+          <var>origin</var>, replace it with <var>policy</var>; otherwise,
+          insert <var>policy</var> into the <a>policy cache</a> for
+          <var>origin</var>.
+        </li>
+
+      </ol>
+    </section>
+  </section>
+
+  <section>
+    <h2>Report delivery</h2>
+
+    <section>
+      <h2>Choose a policy for an origin</h2>
+
+      <p>
+      Given an <a>origin</a> (<var>origin</var>), this algorithm determines
+      which <a>NEL policy</a> in the <a>policy cache</a> should be used to
+      generate reports for <a>network requests</a> to <var>origin</var>.
+      </p>
+
+      <ol>
+
+        <li>
+          If there is an entry in the <a>policy cache</a> for <var>origin</var>:
+          <ol>
+            <li>Let <var>policy</var> be that entry.</li>
+            <li>If <var>policy</var> is not <a>expired</a>, return it.</li>
+          </ol>
+        </li>
+
+        <li>
+          For each <var>parent origin</var> that is a <a>superdomain match</a>
+          of <var>origin</var>:
+
+          <ol>
+            <li>
+              If there is an entry in the <a>policy cache</a> for <var>parent
+                origin</var>:
+              <ol>
+                <li>Let <var>policy</var> be that entry.</li>
+                <li>
+                  If <var>policy</var> is not <a>expired</a>, and its
+                  <a>subdomains</a> flag is <code>include</code>, return it.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+
+        <li>
+          Return <code>no policy</code>.
+        </li>
+
+      </ol>
+
+    </section>
+
+    <section>
+      <h2>Generate a network error report</h2>
+
+      <p>
+      Given a <a>network request</a> (<var>request</var>) and its corresponding
+      <a>response</a> (<var>response</var>), this algorithm generates a report
+      about <var>request</var> if instructed to by any matching <a>NEL
+        policy</a>, and queues it for delivery.
+      </p>
+
+      <ol>
+
+        <li>
+          If the result of executing the <a>is-origin-trustworthy</a> algorithm
+          on <var>request</var>'s <a>origin</a> is <strong>not</strong>
+          <code>Potentially Trustworthy</code>, abort these steps.
+        </li>
+
+        <li>
+          Let <var>origin</var> be <var>request</var>'s <a>origin</a>.
+        </li>
+
+        <li>
+          Let <var>policy</var> be the result of executing <a
+            href="#choose-a-policy-for-an-origin"></a> on <var>origin</var>.  If
+          <var>policy</var> is <code>no policy</code>, abort these steps.
+        </li>
+
+        <li>
+          Determine the active sampling rate for this request:
+
+          <ul>
+            <li>
+              If <var>request</var> <a>succeeded</a>, let <var>sampling rate</var>
+              be <var>policy</var>'s <a>successful sampling rate</a>.
+            </li>
+            <li>
+              If <var>request</var> <a>failed</a>, let <var>sampling rate</var>
+              be <var>policy</var>'s <a>failure sampling rate</a>.
+            </li>
+          </ul>
+        </li>
+
+        <li>
+          Decide whether or not to report on this request.  Let <var>roll</var>
+          be a random number between 0.0 and 1.0, inclusive. If <var>roll</var>
+          ≥ <var>sampling rate</var>, abort these steps.
+        </li>
+
+        <li>
+          Let <var>report body</var> be a new ECMAScript object with the
+          following properties: [[ECMA-262]]
+
+          <dl>
+            <dt><code>uri</code></dt>
+            <dd>
+            <var>request</var>'s URL, with any <a>fragment</a> component
+            removed.
+            </dd>
+
+            <dt><code>referrer</code></dt>
+            <dd>
+            <var>request</var>'s referrer, as determined by the <a>referrer
+              policy</a> associated with its <a>client</a>.
+            </dd>
+
+            <dt><code>sampling_fraction</code></dt>
+            <dd><var>sampling rate</var></dd>
+
+            <dt><code>server_ip</code></dt>
+            <dd>The IP address of the <a>server</a> to which the user agent sent the request, if available. Otherwise, an empty string.
+            <ul>
+              <li>A host identified by an IPv4 address is represented in dotted-decimal notation (a sequence of four decimal numbers in the range 0 to 255, separated by "."). [[RFC1123]]</li>
+              <li>A host identified by an IPv6 address is represented as an ordered list of eight 16-bit pieces (a sequence of `x:x:x:x:x:x:x:x`, where the 'x's are one to four hexadecimal digits of the eight 16-bit pieces of the address). [[RFC4291]] </li>
+            </ul>
+            </dd>
+
+            <dt><code>protocol</code></dt>
+            <dd>
+            The <a>network protocol</a>  used to fetch the resource as
+            identified by the ALPN Protocol ID, if available. Otherwise,
+            <code>""</code>.
+            </dd>
+
+            <dt><code>method</code></dt>
+            <dd><var>request</var>'s <a>request method</a>.</dd>
+
+            <dt><code>status_code</code></dt>
+            <dd>
+            The <a>status code</a> of the HTTP response, if available.
+            Otherwise, <code>0</code>.
+            </dd>
+
+            <dt><code>elapsed_time</code></dt>
+            <dd>
+            The elapsed number of milliseconds between the start of the resource
+            fetch and when it was completed or aborted by the user agent.
+            </dd>
+
+            <dt><code>type</code></dt>
+            <dd>
+            If <var>request</var> <a>failed</a>, the <a>type</a> of its
+            <a>network error</a>.  If <var>request</var> <a>succeeded</a>,
+            <code>"ok"</code>.
+            </dd>
+          </dl>
+        </li>
 
         <li>
           <p><a data-cite="!REPORTING#queue-report">Queue the report for delivery</a> via the Reporting API. [[!REPORTING]]</p>
@@ -507,21 +819,126 @@
             <dt>type</dt>
             <dd><code>network-error</code></dd>
             <dt>data</dt>
-            <dd>the <a>body</a> of the <a>network error report</a> created above</dd>
+            <dd><var>report body</var></dd>
             <dt>endpoint group</dt>
-            <dd>the <a data-lt="report_to">endpoint group</a> defined by the <a>NEL policy</a> of the associated <a>NEL origin</a></dd>
+            <dd><var>policy</var>'s <a>reporting group</a></dd>
             <dt>settings</dt>
-            <dd>the <a data-cite="!HTML#environment-settings-object">environment settings object</a> for the request described by <em>report</em></dd>
+            <dd><var>request</var>'s <a data-cite="!HTML#environment-settings-object">environment settings object</a></dd>
           </dl>
         </li>
       </ol>
+
     </section>
+  </section>
 
     <section>
-      <h2>Sampling rates</h2>
-      <p>A <a>NEL origin</a> that expects to serve a large volume of traffic might not be equipped to ingest NEL reports for every request made to the origin. The origin can define a <dfn>sampling rate</dfn> to limit the number of NEL reports that each user agent submits. Since successful requests should typically greatly outnumber requests that result in a <a>network error</a>, the origin can specify different sampling rates for each.</p>
+      <h2>Predefined network error types</h2>
 
-      <p>The sampling rates are specified as a fraction — a number between 0.0 and 1.0, inclusive — stored in the <a><code>success_fraction</code></a> and <a><code>failure_fraction</code></a> fields of the <a>NEL policy</a>. The user agent will use these fractions to probabilistically decide whether to create a <a>network error report</a> for each individual request to the <a>NEL origin</a>.</p>
+      <p>
+      There are several predefined <a>network error</a> <a>types</a>.
+      </p>
+
+      <p>
+      The user agent MAY extend this list with custom <a>network error</a>
+      <a>types</a> — e.g. to accommodate new protocols, or more detailed error
+      descriptions of existing ones.  When doing so, the user agent SHOULD
+      follow the dot-delimited pattern
+      (<code>[group].[optional-subgroup].[error-name]</code>) for the
+      <a>type</a> names to facilitate simple and consistent processing of the
+      error reports — e.g. the collector may provide aggregation by category
+      and/or one or multiple subgroups.
+      </p>
+
+      <dl class="reportTypeGroup">
+        <dt><code>dns.unreachable</code></dt>
+        <dd>DNS server is unreachable</dd>
+        <dt><code>dns.name_not_resolved</code></dt>
+        <dd>DNS server responded but is unable to resolve the address</dd>
+        <dt><code>dns.failed</code></dt>
+        <dd>Request to the DNS server failed due to reasons not covered by previous errors</dd>
+      </dl>
+
+      <dl class="reportTypeGroup">
+        <dt><code>tcp.timed_out</code></dt>
+        <dd>TCP connection to the server timed out</dd>
+
+        <dt><code>tcp.closed</code></dt>
+        <dd>The TCP connection was closed by the server</dd>
+
+        <dt><code>tcp.reset</code></dt>
+        <dd>The TCP connection was reset</dd>
+
+        <dt><code>tcp.refused</code></dt>
+        <dd>The TCP connection was refused by the server</dd>
+
+        <dt><code>tcp.aborted</code></dt>
+        <dd>The TCP connection was aborted</dd>
+
+        <dt><code>tcp.address_invalid</code></dt>
+        <dd>The IP address is invalid</dd>
+
+        <dt><code>tcp.address_unreachable</code></dt>
+        <dd>The IP address is unreachable</dd>
+
+        <dt><code>tcp.failed</code></dt>
+        <dd>The TCP connection failed due to reasons not covered by previous errors</dd>
+      </dl>
+
+      <dl class="reportTypeGroup">
+        <dt><code>tls.version_or_cipher_mismatch</code></dt>
+        <dd>The TLS connection was aborted due to version or cipher mismatch</dd>
+
+        <dt><code>tls.bad_client_auth_cert</code></dt>
+        <dd>The TLS connection was aborted due to invalid client certificate</dd>
+
+        <dt><code>tls.cert.name_invalid</code></dt>
+        <dd>The TLS connection was aborted due to invalid name</dd>
+
+        <dt><code>tls.cert.date_invalid</code></dt>
+        <dd>The TLS connection was aborted due to invalid certificate date</dd>
+
+        <dt><code>tls.cert.authority_invalid</code></dt>
+        <dd>The TLS connection was aborted due to invalid issuing authority</dd>
+
+        <dt><code>tls.cert.invalid</code></dt>
+        <dd>The TLS connection was aborted due to invalid certificate</dd>
+
+        <dt><code>tls.cert.revoked</code></dt>
+        <dd>The TLS connection was aborted due to revoked server certificate</dd>
+
+        <dt><code>tls.cert.pinned_key_not_in_cert_chain</code></dt>
+        <dd>The TLS connection was aborted due to a key pinning error</dd>
+
+        <dt><code>tls.protocol.error</code></dt>
+        <dd>The TLS connection was aborted due to a TLS protocol error</dd>
+
+        <dt><code>tls.failed</code></dt>
+        <dd>The TLS connection failed due to reasons not covered by previous errors</dd>
+      </dl>
+
+      <dl class="reportTypeGroup">
+        <dt><code>http.protocol.error</code></dt>
+        <dd>The connection was aborted due to an HTTP protocol error</dd>
+
+        <dt><code>http.response.invalid</code></dt>
+        <dd>Response is empty, has a content-length mismatch, has improper encoding, and/or other conditions that prevent user agent from processing the response</dd>
+
+        <dt><code>http.response.redirect_loop</code></dt>
+        <dd>The request was aborted due to a detected redirect loop</dd>
+
+        <dt><code>http.failed</code></dt>
+        <dd>The connection failed due to errors in HTTP protocol not covered by previous errors</dd>
+
+      </dl>
+
+      <dl class="reportTypeGroup">
+        <dt><code>abandoned</code></dt>
+        <dd>User aborted the resource fetch before it is complete</dd>
+
+        <dt><code>unknown</code></dt>
+        <dd>error type is unknown</dd>
+      </dl>
+
     </section>
 
     <section>
@@ -586,11 +1003,12 @@
         <h2>Sample Network Error Reports</h2>
 
         <p>
-        This section contains example <a>network error reports</a> the user
-        agent might queue when a network error is encountered for a <a>known NEL
-          origin</a>.  We show the full report payload that would be created by
-        the [[!REPORTING]] API when uploading the report; the payload's
-        <code>body</code> field contains the <a>network error report body</a>.
+        This section contains example <a>network error</a> <a>reports</a> the
+        user agent might queue when a network error is encountered for an
+        <a>origin</a> with a registered <a>NEL policy</a>.  We show the full
+        report payload that would be created by the [[!REPORTING]] API when
+        uploading the report; the payload's <code>body</code> field contains the
+        <a>network error</a> <a>report body</a>.
         </p>
 
         <pre class="example">
@@ -614,12 +1032,11 @@
 
         <p>
         This report indicates that the user agent attempted to navigate from
-        <code>example.com</code> to <code>www.example.com</code> (<a>known NEL
-          origin</a>), which successfully resolved to the
-        <code>123.122.121.120</code> IP address.  However, while the user agent
-        received a <a>200 response</a> from the server via the HTTP/2
-        (<code>h2</code>) protocol, it encountered a protocol error in the
-        exchange and was forced to abandon the navigation.  The user agent
+        <code>example.com</code> to <code>www.example.com</code>, which
+        successfully resolved to <code>123.122.121.120</code>.  However, while
+        the user agent received a <a>200 response</a> from the server via the
+        HTTP/2 (<code>h2</code>) protocol, it encountered a protocol error in
+        the exchange and was forced to abandon the navigation.  The user agent
         aborted the navigation 823 milliseconds after it started.  Finally, the
         user agent sent this report immediately after the network error was
         encountered – i.e. the report age is 0.
@@ -649,12 +1066,12 @@
         <code>https://widget.com/thing.js</code> from
         <code>https://www.example.com/</code>.  However, the user agent was
         unable to resolve the DNS name (<code>widget.com</code>) and the request
-        was aborted by the user agent after 143 milliseconds.  A previous
-        request to <code>widget.com</code> delivered a valid <a>NEL policy</a>,
-        making <code>widget.com</code> a <a>known NEL origin</a>.  Because of
-        this existing policy, the user agent generates a <a>network error
-          report</a> was logged and uploaded immediately after the network error
-        was encountered – i.e. the report age is 0.
+        was aborted by the user agent after 143 milliseconds.  Because a
+        previous request to <code>widget.com</code> delivered a valid <a>NEL
+          policy</a>, the user agent generates a <a>network error</a>
+        <a>report</a> for this request.  The report was uploaded immediately
+        after the <a>network error</a> was encountered – i.e. the report age is
+        0.
         </p>
 
       </section>
@@ -676,7 +1093,7 @@
 
         <p>A typical application requires dozens of resources, the fetching of which is typically initiated via HTML, CSS, or JavaScript. The application requesting such resources can observe failures of most such fetches (e.g. via `onerror` callbacks), but it does not have access to the detailed network error report of why the failure has occurred - e.g. DNS failure, TCP error, TLS protocol violation, etc.</p>
 
-        <p>To address this, the application can register relevant NEL policies with the user agent for the first-party hosts from which the subresources are being fetched. Then, if such a policy is present and a network error is encountered for a resource associated with a registered <a>NEL origin</a>, the user agent will report the detailed network error report and enable the application developers to investigate the error.</p>
+        <p>To address this, the application can register relevant <a>NEL policies</a> with the user agent for the first-party hosts from which the subresources are being fetched. Then, if such a policy is present and a network error is encountered for a resource from an <a>origin</a> with a registered <a>NEL policy</a>, the user agent will report the detailed network error report and enable the application developers to investigate the error.</p>
       </section>
 
       <section>
@@ -684,14 +1101,14 @@
 
         <p>In the case where a resource is embedded by a third party, the provider of the resource is often unable to instrument and observe the failure. For example, if `example.com` embeds a `widget.com/thing.js` resource on its site, and the user visiting `example.com` fails to fetch such resource due to a network error, the `widget.com` host is both unaware of the failure and unable to detect it.</p>
 
-        <p>To address this, `widget.com` can register an NEL policy for its host. Then, if such policy is present and a network error is encountered while fetching a resource &mdash; regardless of whether it is being requested from a first-party or third-party origin &mdash; from the registered <a>NEL origin</a>, the user agent will report the network error and enable the provider to investigate the error.</p>
+        <p>To address this, `widget.com` can register an NEL policy for its host. Then, if such policy is present and a network error is encountered while fetching a resource &mdash; regardless of whether it is being requested from a first-party or third-party origin &mdash; from the <a>origin</a> with a registered <a>NEL policy</a>, the user agent will report the network error and enable the provider to investigate the error.</p>
       </section>
     </section>
 
     <section>
       <h2>Privacy Considerations</h2>
 
-      <p><a>NEL</a> provides network error reports that could expose new information about the user's network configuration. For example, an attacker could abuse NEL reporting to probe users network configuration. Also, similar to HSTS, HPKP, and pinned CSP policies, the stored <a>NEL policy</a> could be used as a "supercookie" by setting a distinct policy with a custom (per-user) reporting URI to act as an identififer in combination with (or instead of) HTTP cookies.</p>
+      <p>NEL provides network error reports that could expose new information about the user's network configuration. For example, an attacker could abuse NEL reporting to probe users network configuration. Also, similar to HSTS, HPKP, and pinned CSP policies, the stored <a>NEL policy</a> could be used as a "supercookie" by setting a distinct policy with a custom (per-user) reporting URI to act as an identififer in combination with (or instead of) HTTP cookies.</p>
 
       <p>To mitigate some of the above risks, NEL registration is restricted to <a>trustworthy origins</a>, and delivery of network error reports is similarly restricted to <a>trustworthy origins</a>. This disallows a transient HTTP MITM from trivially abusing NEL as a persistent tracker.</p>
 
@@ -710,10 +1127,10 @@
       <p>The permanent message header field registry should be updated with the following registrations ([[RFC3864]]):</p>
 
       <section>
-        <h2>NEL</h2>
+        <h2><code>NEL</code></h2>
         <dl>
           <dt>Header field name</dt>
-          <dd>NEL</dd>
+          <dd><code>NEL</code></dd>
           <dt>Applicable protocol</dt>
           <dd>http</dd>
           <dt>Status</dt>
@@ -721,11 +1138,10 @@
           <dt>Author/Change controller</dt>
           <dd>W3C</dd>
           <dt>Specification document</dt>
-          <dd>This specification (see <a>NEL Header Field</a>)</dd>
+          <dd>This specification (see <a>NEL</a> response header)</dd>
         </dl>
       </section>
     </section>
-  </section>
 
   <section class="appendix">
     <h2>Acknowledgments</h2>


### PR DESCRIPTION
This updates the spec to follow the same basic structure as Reporting, with a separate top-level Concepts section, and separate sections on Policy Delivery and Report Delivery.