### PR TITLE
Update WICG references to W3C

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     wg: "Web Performance Working Group",
     wgURI: "https://www.w3.org/webperf/",
     shortName: "network-error-logging",
-    specStatus: "CG-DRAFT",
-    edDraftURI: "https://wicg.github.io/network-error-logging/",
+    specStatus: "ED",
+    edDraftURI: "https://w3c.github.io/network-error-logging/",
     editors: [{
       name: "Douglas Creager",
       url: "http://dcreager.net/",
@@ -51,13 +51,13 @@
       key: 'Repository',
       data: [{
         value: 'We are on Github.',
-        href: 'https://github.com/wicg/network-error-logging/'
+        href: 'https://github.com/w3c/network-error-logging/'
       }, {
         value: 'File a bug.',
-        href: 'https://github.com/wicg/network-error-logging/issues'
+        href: 'https://github.com/w3c/network-error-logging/issues'
       }, {
         value: 'Commit history.',
-        href: 'https://github.com/wicg/network-error-logging/commits/gh-pages/index.html'
+        href: 'https://github.com/w3c/network-error-logging/commits/gh-pages/index.html'
       }]
     }]
   };
@@ -76,7 +76,6 @@
   </section>
 
   <section id='sotd'>
-  <p>This is a <strong>proposal</strong> and may change without any notices. Interested parties should bring discussions to the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a>.</p>
   </section>
 
   <section>


### PR DESCRIPTION
NEL has been adopted by the Web Performance Working Group, and is therefore now an Editor's Draft instead of a Community Group Draft.  Addresses #86 