### PR TITLE
Remove redundant URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,6 @@
       <dt>data</dt>
       <dd><pre class="highlight">
 {
-  "uri": "https://www.example.com/resource",
   "referrer": "https://referrer.com/",
   "sampling_fraction": 1.0,
   "server_ip": "123.122.121.120",
@@ -889,12 +888,6 @@
           following properties: [[ECMA-262]]
 
           <dl>
-            <dt><code>uri</code></dt>
-            <dd>
-            <var>request</var>'s URL, with any <a>fragment</a> component
-            removed.
-            </dd>
-
             <dt><code>referrer</code></dt>
             <dd>
             <var>request</var>'s referrer, as determined by the <a>referrer
@@ -1007,6 +1000,8 @@
             <dd><var>policy</var>'s <a>reporting group</a></dd>
             <dt>settings</dt>
             <dd><var>request</var>'s <a data-cite="!HTML#environment-settings-object">environment settings object</a></dd>
+            <dt>url</dt>
+            <dd><var>request</var>'s URL</dd>
           </dl>
         </li>
       </ol>
@@ -1222,7 +1217,6 @@
   "type": "network-error",
   "url": "https://www.example.com/",
   "body": {
-    "uri": "https://www.example.com/",
     "sampling_fraction": 0.5,
     "referrer": "http://example.com/",
     "server_ip": "123.122.121.120",
@@ -1253,7 +1247,6 @@
   "type": "network-error",
   "url": "https://widget.com/thing.js",
   "body": {
-    "uri": "https://widget.com/thing.js",
     "sampling_fraction": 1.0,
     "referrer": "https://www.example.com/",
     "server_ip": "",
@@ -1311,7 +1304,6 @@
   "type": "network-error",
   "url": "https://new-subdomain.example.com/",
   "body": {
-    "uri": "https://new-subdomain.example.com/",
     "sampling_fraction": 1.0,
     "server_ip": "",
     "protocol": "http/1.1",
@@ -1380,7 +1372,6 @@
   "type": "network-error",
   "url": "https://example.com/",
   "body": {
-    "uri": "https://example.com/",
     "sampling_fraction": 1.0,
     "server_ip": "192.168.0.1",
     "protocol": "http/1.1",
@@ -1410,7 +1401,6 @@
   "type": "network-error",
   "url": "https://example.com/",
   "body": {
-    "uri": "https://example.com/",
     "sampling_fraction": 1.0,
     "server_ip": "192.168.0.2",
     "protocol": "http/1.1",
@@ -1444,7 +1434,6 @@
   "type": "network-error",
   "url": "https://example.com/",
   "body": {
-    "uri": "https://example.com/",
     "sampling_fraction": 1.0,
     "server_ip": "192.168.0.3",
     "protocol": "http/1.1",
@@ -1475,7 +1464,6 @@
   "type": "network-error",
   "url": "https://example.com/",
   "body": {
-    "uri": "https://example.com/",
     "sampling_fraction": 1.0,
     "server_ip": "192.168.0.1",
     "protocol": "http/1.1",


### PR DESCRIPTION
The Reporting API now lets us provide a custom URL to associate the report with.  The default is to use the containing document's URL, which isn't relevant for a NEL report.  This lets us remove the `uri` field from the NEL body, removing a source of confusion about why they're different.