### PR TITLE
Introduce a new algorithm "Deliver a network report".

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,6 +529,58 @@
       </ul>
     </section>
 
+    <section data-dfn-for="AdditionalReportBody"data-link-for="AdditionalReportBody">
+      <h2>Additional report body</h2>
+
+      <p>
+      An <dfn>AdditionalReportBody</dfn> is a WebIDL dictionary defined by this
+      IDL.
+      </p>
+
+      <pre class="idl">
+        dictionary AdditionalReportBody {
+          ByteString? phase;
+          ByteString? type;
+          long? elapsed_time;
+          ByteString? outer_url;
+          ByteString? inner_url;
+          ByteString? cert_url;
+        };
+      </pre>
+      <dl>
+        <dt><dfn>phase</dfn></dt>
+        <dd>
+        The OPTINAL <var>phase</var> member is used to override the
+        <code>phase</code> property of <var>report body</var>.
+        </dd>
+        <dt><dfn>type</dfn></dt>
+        <dd>
+        The OPTINAL <var>type</var> member is used to override the
+        <code>type</code> property of <var>report body</var>.
+        </dd>
+        <dt><dfn>elapsed_time</dfn></dt>
+        <dd>
+        The OPTINAL <var>elapsed_time</var> member is used to override the
+        <code>elapsed_time</code> property of <var>report body</var>.
+        </dd>
+        <dt><dfn>outer_url</dfn></dt>
+        <dd>
+        The OPTINAL <var>outer_url</var> member is used to append the URL of
+        outer request of signed exchange to <var>report body</var>.
+        </dd>
+        <dt><dfn>inner_url</dfn></dt>
+        <dd>
+        The OPTINAL <var>inner_url</var> member is used to append the URL of
+        inner request of signed exchange to <var>report body</var>.
+        </dd>
+        <dt><dfn>cert_url</dfn></dt>
+        <dd>
+        The OPTINAL <var>cert_url</var> member is used to append the URL of
+        certificate of signed exchange to <var>report body</var>.
+        </dd>
+      </dl>
+    </section>
+
   </section>
 
   <section>
@@ -1022,10 +1074,10 @@
 
       <p>
       Given a <a>network request</a> (<var>request</var>) and its corresponding
-      <a>response</a> (<var>response</var>) and an OPTIONAL ECMAScript object
-      (<var>additional body</var>), this algorithm generates a report about
-      <var>request</var> if instructed to by any matching <a>NEL policy</a>, and
-      queues it for delivery.
+      <a>response</a> (<var>response</var>) and an OPTIONAL
+      <a>AdditionalReportBody</a> object (<var>additional body</var>), this
+      algorithm generates a report about <var>request</var> if instructed to by
+      any matching <a>NEL policy</a>, and queues it for delivery.
       </p>
 
       <ol class="algorithm">
@@ -1140,7 +1192,7 @@
           </dl>
         </li>
         <li>
-          If <var>additional body</var> is present, set each properties of
+          If <var>additional body</var> is present, set each members of
           <var>additional body</var> to <var>report body</var>.
         </li>
 

--- a/index.html
+++ b/index.html
@@ -1024,7 +1024,8 @@
       Given a <a>network request</a> (<var>request</var>) and its corresponding
       <a>response</a> (<var>response</var>), this algorithm generates a report
       about <var>request</var> if instructed to by any matching <a>NEL
-        policy</a>.
+        policy</a>, and returns the report and the NEL policy. Otherwise this
+      algorithm returns null.
       </p>
 
       <ol class="algorithm">
@@ -1198,8 +1199,10 @@
       <h2 id="deliver-a-network-report" data-dfn-type="dfn"
           data-export>Deliver a network report</h2>
       <p>
-      Given a ECMAScript object (<var>report body</var>) and its matching
-      <a>NEL policy</a> (<var>policy</var>) and <a>network request</a>
+      Given a ECMAScript object (<var>report body</var>, usually returned from
+      <a href="#generate-a-network-error-report">Generate a network error
+        report</a> and then augmented by the calling specification) and its
+      matching <a>NEL policy</a> (<var>policy</var>) and <a>network request</a>
       (<var>request</var>), this algorithm queues the report for delivery.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -1022,9 +1022,10 @@
 
       <p>
       Given a <a>network request</a> (<var>request</var>) and its corresponding
-      <a>response</a> (<var>response</var>), this algorithm generates a report
-      about <var>request</var> if instructed to by any matching <a>NEL
-        policy</a>, and queues it for delivery.
+      <a>response</a> (<var>response</var>) and an OPTIONAL ECMAScript object
+      (<var>additional body</var>), this algorithm generates a report about
+      <var>request</var> if instructed to by any matching <a>NEL policy</a>, and
+      queues it for delivery.
       </p>
 
       <ol class="algorithm">
@@ -1137,6 +1138,10 @@
             <code>"ok"</code>.
             </dd>
           </dl>
+        </li>
+        <li>
+          If <var>additional body</var> is present, set each properties of
+          <var>additional body</var> to <var>report body</var>.
         </li>
 
         <li>

--- a/index.html
+++ b/index.html
@@ -529,58 +529,6 @@
       </ul>
     </section>
 
-    <section data-dfn-for="AdditionalReportBody"data-link-for="AdditionalReportBody">
-      <h2>Additional report body</h2>
-
-      <p>
-      An <dfn>AdditionalReportBody</dfn> is a WebIDL dictionary defined by this
-      IDL.
-      </p>
-
-      <pre class="idl">
-        dictionary AdditionalReportBody {
-          ByteString? phase;
-          ByteString? type;
-          long? elapsed_time;
-          ByteString? outer_url;
-          ByteString? inner_url;
-          ByteString? cert_url;
-        };
-      </pre>
-      <dl>
-        <dt><dfn>phase</dfn></dt>
-        <dd>
-        The OPTINAL <var>phase</var> member is used to override the
-        <code>phase</code> property of <var>report body</var>.
-        </dd>
-        <dt><dfn>type</dfn></dt>
-        <dd>
-        The OPTINAL <var>type</var> member is used to override the
-        <code>type</code> property of <var>report body</var>.
-        </dd>
-        <dt><dfn>elapsed_time</dfn></dt>
-        <dd>
-        The OPTINAL <var>elapsed_time</var> member is used to override the
-        <code>elapsed_time</code> property of <var>report body</var>.
-        </dd>
-        <dt><dfn>outer_url</dfn></dt>
-        <dd>
-        The OPTINAL <var>outer_url</var> member is used to append the URL of
-        outer request of signed exchange to <var>report body</var>.
-        </dd>
-        <dt><dfn>inner_url</dfn></dt>
-        <dd>
-        The OPTINAL <var>inner_url</var> member is used to append the URL of
-        inner request of signed exchange to <var>report body</var>.
-        </dd>
-        <dt><dfn>cert_url</dfn></dt>
-        <dd>
-        The OPTINAL <var>cert_url</var> member is used to append the URL of
-        certificate of signed exchange to <var>report body</var>.
-        </dd>
-      </dl>
-    </section>
-
   </section>
 
   <section>
@@ -1074,10 +1022,9 @@
 
       <p>
       Given a <a>network request</a> (<var>request</var>) and its corresponding
-      <a>response</a> (<var>response</var>) and an OPTIONAL
-      <a>AdditionalReportBody</a> object (<var>additional body</var>), this
-      algorithm generates a report about <var>request</var> if instructed to by
-      any matching <a>NEL policy</a>, and queues it for delivery.
+      <a>response</a> (<var>response</var>), this algorithm generates a report
+      about <var>request</var> if instructed to by any matching <a>NEL
+        policy</a>.
       </p>
 
       <ol class="algorithm">
@@ -1085,8 +1032,8 @@
         <li>
           If the result of executing the <a>"Is origin potentially
             trustworthy?"</a> algorithm on <var>request</var>'s <a>origin</a> is
-          <strong>not</strong> <code>Potentially Trustworthy</code>, abort these
-          steps.
+          <strong>not</strong> <code>Potentially Trustworthy</code>, return
+          null.
         </li>
 
         <li>
@@ -1096,7 +1043,7 @@
         <li>
           Let <var>policy</var> be the result of executing <a
             href="#choose-a-policy-for-an-origin"></a> on <var>origin</var>.  If
-          <var>policy</var> is <code>no policy</code>, abort these steps.
+          <var>policy</var> is <code>no policy</code>, return null.
         </li>
 
         <li>
@@ -1117,7 +1064,7 @@
         <li>
           Decide whether or not to report on this request.  Let <var>roll</var>
           be a random number between 0.0 and 1.0, inclusive. If <var>roll</var>
-          ≥ <var>sampling rate</var>, abort these steps.
+          ≥ <var>sampling rate</var>, return null.
         </li>
 
         <li>
@@ -1191,10 +1138,6 @@
             </dd>
           </dl>
         </li>
-        <li>
-          If <var>additional body</var> is present, set each members of
-          <var>additional body</var> to <var>report body</var>.
-        </li>
 
         <li>
           If <var>report body</var>'s <code>phase</code> property is not
@@ -1242,9 +1185,25 @@
           data-lt="policy origin">origin</a>, <var>policy</var>'s
           <a>subdomains</a> flag is <code>include</code>, and <var>report
           body</var>'s <code>phase</code> property is not <code>dns</code>,
-          abort these steps.
+          return null.
         </li>
 
+        <li>
+          Return <var>report body</var> and <var>policy</var>.
+        </li>
+      </ol>
+
+    </section>
+    <section>
+      <h2 id="deliver-a-network-report" data-dfn-type="dfn"
+          data-export>Deliver a network report</h2>
+      <p>
+      Given a ECMAScript object (<var>report body</var>) and its matching
+      <a>NEL policy</a> (<var>policy</var>) and <a>network request</a>
+      (<var>request</var>), this algorithm queues the report for delivery.
+      </p>
+
+      <ol class="algorithm">
         <li>
           <p><a data-cite="!REPORTING#queue-report">Queue the report for delivery</a> via the Reporting API. [[!REPORTING]]</p>
 
@@ -1262,7 +1221,6 @@
           </dl>
         </li>
       </ol>
-
     </section>
   </section>
 


### PR DESCRIPTION
I want to introduce an OPTIONAL `additional body` to the algorithm of "Generate a network error report".

This will be used to send the signed exchange reports https://github.com/w3c/network-error-logging/issues/99 from the spec of "Loading Signed Exchanges" https://github.com/WICG/webpackage/pull/374.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/horo-t/network-error-logging/pull/100.html" title="Last updated on Jan 29, 2019, 3:19 AM UTC (ded837b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/100/49c04de...horo-t:ded837b.html" title="Last updated on Jan 29, 2019, 3:19 AM UTC (ded837b)">Diff</a>