### PR TITLE
Export "Generate a network error report".

### DIFF
--- a/index.html
+++ b/index.html
@@ -1017,7 +1017,8 @@
     </section>
 
     <section>
-      <h2>Generate a network error report</h2>
+      <h2 id="generate-a-network-error-report" data-dfn-type="dfn"
+          data-export>Generate a network error report</h2>
 
       <p>
       Given a <a>network request</a> (<var>request</var>) and its corresponding


### PR DESCRIPTION
So bikeshed specs can more easily depend on it.

Used in https://github.com/WICG/webpackage/pull/374, and https://github.com/tabatkins/bikeshed/issues/1422 asks to index the spec as a whole.