### PR TITLE
Export "NEL policy"

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@
       <h2>NEL policies</h2>
 
       <p>
-      A <dfn data-lt="NEL policies">NEL policy</dfn> instructs a user agent
+      A <dfn data-lt="NEL policies" data-export>NEL policy</dfn> instructs a user agent
       whether to collect reports about <a>network requests</a> to an
       <a>origin</a>, and if so, where to send them.  <a>NEL policies</a> are
       delivered to the user agent via HTTP <a>response headers</a>.


### PR DESCRIPTION
Used in the example at https://wicg.github.io/webpackage/loading.html#example-network-error-log. Since that's just an example, we could also just target the unexported dfn directly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/network-error-logging/pull/113.html" title="Last updated on May 24, 2019, 9:05 PM UTC (fe81bd2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/113/f01bdf4...jyasskin:fe81bd2.html" title="Last updated on May 24, 2019, 9:05 PM UTC (fe81bd2)">Diff</a>