### PR TITLE
Update WG ReSpec config

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,7 @@
   <script src='https://www.w3.org/Tools/respec/respec-w3c' defer class='remove'></script>
   <script class='remove'>
   var respecConfig = {
-    wg: "Web Performance Working Group",
-    wgURI: "https://www.w3.org/webperf/",
+    group: "webperf",
     shortName: "network-error-logging",
     specStatus: "ED",
     edDraftURI: "https://w3c.github.io/network-error-logging/",


### PR DESCRIPTION
ReSpec now takes a short name for the WG responsible for this document, rather than a set of configuration parameters. Updated to "webperf".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/pull/128.html" title="Last updated on Nov 23, 2020, 8:54 PM UTC (78e62e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/128/538e371...78e62e1.html" title="Last updated on Nov 23, 2020, 8:54 PM UTC (78e62e1)">Diff</a>