### PR TITLE
Clarify that include_subdomains covers unlimited subdomain depth

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,9 +594,10 @@
         <p>
         The OPTIONAL <dfn><code>include_subdomains</code></dfn> member is a
         boolean that enables this <a>NEL policy</a> for all subdomains of this
-        origin.  If no member named <code>include_subdomains</code> is present
-        in the object, or its value is not <code>true</code>, the <a>NEL
-        policy</a> will not be enabled for subdomains.
+        origin (to an unlimited subdomain depth).  If no member named 
+        <code>include_subdomains</code> is present in the object, or its value 
+        is not <code>true</code>, the <a>NEL policy</a> will not be enabled 
+        for subdomains.  
         </p>
 
         <p class="note">


### PR DESCRIPTION
Follows from @clelland [comment](https://github.com/w3c/network-error-logging/issues/135#issuecomment-1537693670) in #135 