### PR TITLE
Ensure that subdomain policies are only for DNS.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1137,6 +1137,22 @@
         </li>
 
         <li>
+          If <var>origin</var> is not equal to <var>policy</var>'s <a
+          data-lt="policy origin">origin</a>, <var>policy</var>'s
+          <a>subdomains</a> flag is <code>include</code>, and <var>report
+          body</var>'s <code>phase</code> property is not <code>dns</code>,
+          return null.
+
+          <p class="note">
+          This step ensures that <a data-lt="subdomains">subdomain</a> <a>NEL
+          policies</a> can only be used to generate reports about subdomains of
+          the <a>policy origin</a> during the <a>DNS resolution</a> phase of a
+          <a>request</a>. See <a href="#privacy-considerations"></a> for more
+          details.
+          </p>
+        </li>
+
+        <li>
           If <var>report body</var>'s <code>phase</code> property is not
           <code>dns</code>, and <var>report body</var>'s <code>server_ip</code>
           property is non-empty and not equal to <var>policy</var>'s <a>received
@@ -1175,14 +1191,6 @@
           <a>DNS resolution</a>.  See <a href="#privacy-considerations"></a> and
           <a href="#origins-with-multiple-ip-addresses"></a> for more details.
           </p>
-        </li>
-
-        <li>
-          If <var>origin</var> is not equal to <var>policy</var>'s <a
-          data-lt="policy origin">origin</a>, <var>policy</var>'s
-          <a>subdomains</a> flag is <code>include</code>, and <var>report
-          body</var>'s <code>phase</code> property is not <code>dns</code>,
-          return null.
         </li>
 
         <li>


### PR DESCRIPTION
This CL moves the subdomain check -- which is supposed to ensure that only DNS errors are reported for subdomains -- before the step which can downgrade reports, since that step can change some reports into DNS reports, even they were not originally.

Closes: #141


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/pull/144.html" title="Last updated on Jun 7, 2023, 9:47 PM UTC (0fd893e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/144/09c74af...0fd893e.html" title="Last updated on Jun 7, 2023, 9:47 PM UTC (0fd893e)">Diff</a>