### PR TITLE
Make NEL policies stale after 48h

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,6 +472,11 @@
       </p>
 
       <p>
+      A <a>NEL policy</a> is <dfn>stale</dfn> if its <a>creation</a> plus
+      172800 seconds (48 hours) represents a time in the past.
+      </p>
+
+      <p>
       A <a>NEL policy</a> is <dfn>expired</dfn> if its <a>creation</a> plus its
       <a>ttl</a> represents a time in the past.
       </p>
@@ -1206,6 +1211,11 @@
           <a>DNS resolution</a>.  See <a href="#privacy-considerations"></a> and
           <a href="#origins-with-multiple-ip-addresses"></a> for more details.
           </p>
+        </li>
+
+        <li>
+          If <var>policy</var> is <a>stale</a>, then delete <var>policy</var>
+          from the <a>policy cache</a>.
         </li>
 
         <li>

--- a/index.html
+++ b/index.html
@@ -147,6 +147,14 @@
             <li><dfn data-cite="!FETCH#concept-response-trailer">response trailer</dfn></li>
           </ul>
         </dd>
+        <dt>High Resolution Time</dt>
+        <dd>
+          <p>The following terms are defined in the High Resolution Time specification: [[HR-TIME]]</p>
+          <ul>
+            <li><dfn data-cite="!HR-TIME#dfn-current-wall-time">current wall time</dfn></li>
+            <li><dfn data-cite="!HR-TIME#dfn-duration-from">duration from</dfn></li>
+          </ul>
+        </dd>
         <dt>HSTS</dt>
         <dd>
           <p>The following terms are defined in the HSTS specification: [[RFC6797]]</p>
@@ -472,13 +480,15 @@
       </p>
 
       <p>
-      A <a>NEL policy</a> is <dfn>stale</dfn> if its <a>creation</a> plus
-      172800 seconds (48 hours) represents a time in the past.
+      A <a>NEL policy</a> is <dfn>stale</dfn> if the <a>duration from</a> its
+      <a>creation</a> to the <a>current wall time</a> is greater than 172800
+      seconds (48 hours).
       </p>
 
       <p>
-      A <a>NEL policy</a> is <dfn>expired</dfn> if its <a>creation</a> plus its
-      <a>ttl</a> represents a time in the past.
+      A <a>NEL policy</a> is <dfn>expired</dfn> if the <a>duration from</a> its
+      <a>creation</a> to the <a>current wall time</a> is greater than its
+      <a>ttl</a> (in seconds).
       </p>
     </section>
 
@@ -828,7 +838,7 @@
             <dd>the value of <var>item</var>'s <a>max_age</a> member</dd>
 
             <dt><a>creation</a></dt>
-            <dd>the current timestamp</dd>
+            <dd>the <a>current wall time</a></dd>
 
             <dt><a>successful sampling rate</a></dt>
             <dd>


### PR DESCRIPTION
This attemps to ensure that an attacker who can inject a NEL policy for a small time window cannot cause that policy to persist forever. All policies will have a 48h "freshness" window, after which they need to be refreshed. When stale, they will still be used to send a final report, if a network error occurs, as long as they are not expired (that is, while they are still within their `max_age` expiry time).

Closes: #139


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/pull/147.html" title="Last updated on Jun 27, 2023, 2:29 PM UTC (ec59243)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/147/f1209d7...ec59243.html" title="Last updated on Jun 27, 2023, 2:29 PM UTC (ec59243)">Diff</a>