### PR TITLE
Remove trailer processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,6 @@
             <li><dfn data-cite="!FETCH#concept-request-header-list">request header list</dfn></li>
             <li><dfn data-cite="!FETCH#concept-response" data-lt="responses">response</dfn></li>
             <li><dfn data-cite="!FETCH#concept-response-header-list">response header list</dfn></li>
-            <li><dfn data-cite="!FETCH#concept-response-trailer">response trailer</dfn></li>
           </ul>
         </dd>
         <dt>HSTS</dt>
@@ -985,11 +984,9 @@
           <ol>
             <li>
               If <var>response</var>'s <a data-lt="response header list">header
-                list</a> does not <a data-lt="header list contains">contain</a>
-              <var>header name</var>, AND <var>response</var>'s <a
-                data-lt="response trailer">trailer</a> does not <a
-                data-lt="header list contains">contain</a> <var>header
-                name</var>, skip to the next <var>header name</var> in the list.
+              list</a> does not <a data-lt="header list contains">contain</a>
+              <var>header name</var>, skip to the next <var>header name</var> in
+              the list.
             </li>
 
             <li>
@@ -1000,14 +997,6 @@
               For each <var>header</var> in <var>response</var>'s <a
                 data-lt="response header list">header list</a> whose <a
                 data-lt="header name">name</a> is <var>header name</var>, append
-              <var>header</var>'s <a data-lt="header value">value</a> to
-              <var>values</var>.
-            </li>
-
-            <li>
-              For each <var>header</var> in <var>response</var>'s <a
-                data-lt="response trailer">trailer</a> whose <a data-lt="header
-                name">name</a> is <var>header name</var>, append
               <var>header</var>'s <a data-lt="header value">value</a> to
               <var>values</var>.
             </li>


### PR DESCRIPTION
This removes the processing step in Extract Response Headers which also adds HTTP trailer fields to the report. Trailers are no longer exposed by Fetch, which this builds on, and generally not supported on the Web.

Closes: #146


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/pull/148.html" title="Last updated on Jun 9, 2023, 5:44 PM UTC (6bc150c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/148/f1209d7...6bc150c.html" title="Last updated on Jun 9, 2023, 5:44 PM UTC (6bc150c)">Diff</a>