### PR TITLE
Remove settings from example report

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,8 +88,6 @@
       <dd><code>"network-error"</code></dd>
       <dt>endpoint group</dt>
       <dd>the endpoint group configured by the <a>report_to</a> field</dd>
-      <dt>settings</dt>
-      <dd>TODO</dd>
       <dt>data</dt>
       <dd><pre class="highlight">
 {


### PR DESCRIPTION
This hails back to a previous version of the spec at d22a1b1d053de43ec6e98c92c52ca8080c06a6ba.

The TODO was added a bit before that (https://github.com/w3c/network-error-logging/commit/df0af4631caa4fcc54bee5bbe39f1c8a4e289e2d).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/network-error-logging/pull/179.html" title="Last updated on Feb 4, 2025, 2:05 AM UTC (9cc0258)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/179/a19bf38...miketaylr:9cc0258.html" title="Last updated on Feb 4, 2025, 2:05 AM UTC (9cc0258)">Diff</a>