### PR TITLE
Correct sample rate calculation comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -938,7 +938,7 @@
         <li>
           Decide whether or not to report on this request.  Let <var>roll</var>
           be a random number between 0.0 and 1.0, inclusive. If <var>roll</var>
-          ≥ <var>sampling rate</var>, return null.
+          &gt; <var>sampling rate</var>, return null.
         </li>
 
         <li>


### PR DESCRIPTION
Fixes the issue mentioned in #189 .


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/PontusHanssen/network-error-logging/pull/190.html" title="Last updated on Mar 12, 2025, 9:11 AM UTC (c31b167)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/network-error-logging/190/d8a9916...PontusHanssen:c31b167.html" title="Last updated on Mar 12, 2025, 9:11 AM UTC (c31b167)">Diff</a>